### PR TITLE
Add content type headers

### DIFF
--- a/http-mclient/http-mclient.cabal
+++ b/http-mclient/http-mclient.cabal
@@ -69,6 +69,7 @@ library
     , base
     , bounded
     , bytestring
+    , case-insensitive
     , conversions
     , exceptions
     , http-client

--- a/http-mclient/package.yaml
+++ b/http-mclient/package.yaml
@@ -76,6 +76,7 @@ library:
     - aeson
     - bounded
     - bytestring
+    - case-insensitive
     - conversions
     - http-client
     - http-media

--- a/http-mclient/src/Network/HTTP/MClient.hs
+++ b/http-mclient/src/Network/HTTP/MClient.hs
@@ -17,12 +17,13 @@ import Data.Conversions (Conversion, ToText, convertUnsafe, toText)
 import Data.Conversions.FromType (fromType)
 import GHC.Records (HasField(..))
 import MPrelude
-import Network.HTTP.Media (MediaType, (//), (/:), matches, parseAccept)
+import Network.HTTP.Media (MediaType, (//), (/:))
 import Network.HTTP.Types (hContentType, statusCode)
 
 import qualified Data.ByteString.Lazy.Char8 as LBS
 import qualified Data.List                  as List
 import qualified Data.List.NonEmpty         as NE
+import qualified Network.HTTP.Media         as Media
 import qualified Network.HTTP.Client        as HTTP
 
 type Response = HTTP.Response LBS.ByteString
@@ -101,7 +102,7 @@ mkRequest' expectedStatus httpManager decodeBody request = do
 
   if | code /= expectedStatus ->
         throwError $ InvalidStatusCode code response
-     | not (List.any (`matches` contentType) accepts) ->
+     | not (List.any (`Media.matches` contentType) accepts) ->
         throwError $ UnsupportedContentType contentType response
      | otherwise              -> liftEither
          . left (flip DecodeFailure response . DecodeError . toText)
@@ -116,6 +117,6 @@ catchConnectionError action =
 getContentType :: Response -> Either HttpError MediaType
 getContentType response
   = maybe (Left $ InvalidContentType response) pure
-  . maybe (pure $ mediaType @'PlainText) parseAccept
+  . maybe (pure $ mediaType @'PlainText) Media.parseAccept
   . List.lookup hContentType
   $ HTTP.responseHeaders response

--- a/http-mclient/src/Network/HTTP/MClient.hs
+++ b/http-mclient/src/Network/HTTP/MClient.hs
@@ -6,6 +6,7 @@ module Network.HTTP.MClient
   , HttpError (..)
   , StatusCode
   , mkRequest
+  , mkRequest'
   ) where
 
 import Control.Arrow (left)


### PR DESCRIPTION
Zendesk API-requests require content-type headers in the request headers. What sucks is the error they provide that gets you to think this might be the culprit for request failures is not related to this at all.