### PR TITLE
Change to maintainer friendly version bounds

### DIFF
--- a/bounded/bounded.cabal
+++ b/bounded/bounded.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 3f9a1035998e31229b4aafa8faf2c6775b5a525bc0df762fd86121baa6fe7a00
+-- hash: 967f5ab78b6d2a42777227a7610d9065f54882e7576c2c1727cb2e18bfdebeaf
 
 name:           bounded
 version:        0.0.1
@@ -67,11 +67,11 @@ library
   build-depends:
       aeson >=1.3
     , base
-    , conversions >=0.0.2
+    , conversions
     , mtl
     , scientific
     , symbols
-    , text >=1.2
+    , text
   if flag(development)
     ghc-options: -Werror -fplugin=SourceConstraints
     build-depends:
@@ -111,9 +111,14 @@ test-suite readme
       ViewPatterns
   ghc-options: -Wall -Wcompat -Werror -Widentities -Wimplicit-prelude -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-local-signatures -Wmissing-signatures -Wmonomorphism-restriction -Wredundant-constraints -fhide-source-paths -fplugin-opt=SourceConstraints:local:Blastschield -funbox-strict-fields -optP-Wno-nonportable-include-path -rtsopts -threaded -with-rtsopts=-N -pgmL markdown-unlit -Wno-unused-top-binds
   build-depends:
-      base
+      aeson >=1.3
+    , base
     , bounded
+    , conversions
     , markdown-unlit
+    , mtl
+    , scientific
+    , symbols
     , text
   if flag(development)
     ghc-options: -Werror -fplugin=SourceConstraints
@@ -164,11 +169,16 @@ test-suite test
       aeson >=1.3
     , base
     , bounded
-    , devtools >=0.1.0
+    , conversions
+    , devtools
+    , mtl
+    , scientific
     , should-not-typecheck
-    , source-constraints >=0.0.2 && <0.1
+    , source-constraints
+    , symbols
     , tasty
     , tasty-hunit
+    , text
     , type-spec
   if flag(development)
     ghc-options: -Werror -fplugin=SourceConstraints

--- a/bounded/package.yaml
+++ b/bounded/package.yaml
@@ -32,30 +32,29 @@ default-extensions:
 - TypeOperators
 - ViewPatterns
 
+dependencies:
+- aeson       >= 1.3
+- base
+- conversions
+- mtl
+- scientific
+- symbols
+- text
+
 library:
   source-dirs: src
-  dependencies:
-  - base
-  - aeson              >= 1.3
-  - conversions        >= 0.0.2
-  - mtl
-  - scientific
-  - symbols
-  - text               >= 1.2
 
 tests:
   test:
     <<: *test
     dependencies:
-    - aeson              >= 1.3
-    - base
     - bounded
     - should-not-typecheck
-    - source-constraints ^>= 0.0.2
+    - source-constraints
     - tasty
     - tasty-hunit
     - type-spec
-    - devtools >= 0.1.0
+    - devtools
 
   readme:
     main: README.lhs

--- a/bounded/test/stack-8.10-dependencies.txt
+++ b/bounded/test/stack-8.10-dependencies.txt
@@ -79,7 +79,7 @@ strict 0.4.0.1
 syb 0.7.2.1
 symbols 0.3.0.0
 tagged 0.8.6.1
-tasty 1.3.1
+tasty 1.4.2
 tasty-expected-failure 0.12.3
 tasty-hunit 0.10.0.3
 tasty-mgolden 0.0.2

--- a/bounded/test/stack-9.0-dependencies.txt
+++ b/bounded/test/stack-9.0-dependencies.txt
@@ -79,7 +79,7 @@ strict 0.4.0.1
 syb 0.7.2.1
 symbols 0.3.0.0
 tagged 0.8.6.1
-tasty 1.3.1
+tasty 1.4.2
 tasty-expected-failure 0.12.3
 tasty-hunit 0.10.0.3
 tasty-mgolden 0.0.2

--- a/cbt/cbt.cabal
+++ b/cbt/cbt.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: e6ecf121919cea04d002e4a91a41ec0920aa68300239fb4276c328812124bb37
+-- hash: f0b7050bde383d8c7087151538a99a419d4f4d14c17825a354483e2c80b6a6b7
 
 name:           cbt
 version:        0.1.0
@@ -73,28 +73,28 @@ library
   ghc-options: -Wall -Wcompat -Werror -Widentities -Wimplicit-prelude -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-local-signatures -Wmissing-signatures -Wmonomorphism-restriction -Wredundant-constraints -fhide-source-paths -fplugin-opt=SourceConstraints:local:Blastschield -funbox-strict-fields -optP-Wno-nonportable-include-path
   build-depends:
       base
-    , bytestring ==0.10.*
-    , conduit >=1.3.3 && <1.4
-    , conversions >=0.0.3 && <0.1
-    , cryptonite >=0.25 && <=0.29
-    , exceptions ==0.10.*
-    , hashable ==1.3.*
-    , mprelude ==0.2.*
-    , mrio-core >=0.0.1 && <0.1
-    , mrio-log >=0.0.1 && <0.1
-    , mtl ==2.2.*
-    , pathtype ==0.8.*
-    , resourcet >=1.2.4 && <1.3
-    , source-constraints >=0.0.1 && <0.1
-    , tar ==0.5.*
+    , bytestring
+    , conduit >=1.3.3
+    , conversions
+    , cryptonite >=0.25
+    , exceptions >=0.10
+    , hashable >=1.3
+    , mprelude >=0.2
+    , mrio-core
+    , mrio-log
+    , mtl
+    , pathtype >=0.8
+    , resourcet >=1.2.4
+    , source-constraints
+    , tar >=0.5
     , template-haskell
-    , text ==1.2.*
-    , th-lift-instances ==0.1.*
-    , typed-process ==0.2.*
-    , unliftio ==0.2.*
-    , unliftio-core ==0.2.*
-    , unordered-containers ==0.2.*
-    , uuid ==1.3.*
+    , text
+    , th-lift-instances >=0.1
+    , typed-process >=0.2
+    , unliftio >=0.2
+    , unliftio-core >=0.2
+    , unordered-containers >=0.2
+    , uuid >=1.3
   if flag(development)
     ghc-options: -Werror -fplugin=SourceConstraints
     build-depends:
@@ -141,32 +141,32 @@ test-suite test
   ghc-options: -Wall -Wcompat -Werror -Widentities -Wimplicit-prelude -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-local-signatures -Wmissing-signatures -Wmonomorphism-restriction -Wredundant-constraints -fhide-source-paths -fplugin-opt=SourceConstraints:local:Blastschield -funbox-strict-fields -optP-Wno-nonportable-include-path -rtsopts -threaded -with-rtsopts=-N
   build-depends:
       base
-    , bytestring ==0.10.*
+    , bytestring
     , cbt
-    , conduit >=1.3.3 && <1.4
-    , conversions >=0.0.3 && <0.1
-    , cryptonite >=0.25 && <=0.29
+    , conduit >=1.3.3
+    , conversions
+    , cryptonite >=0.25
     , devtools
-    , exceptions ==0.10.*
-    , hashable ==1.3.*
-    , mprelude ==0.2.*
-    , mrio-core >=0.0.1 && <0.1
-    , mrio-log >=0.0.1 && <0.1
-    , mtl ==2.2.*
-    , pathtype ==0.8.*
-    , resourcet >=1.2.4 && <1.3
-    , source-constraints >=0.0.1 && <0.1
-    , tar ==0.5.*
+    , exceptions >=0.10
+    , hashable >=1.3
+    , mprelude >=0.2
+    , mrio-core
+    , mrio-log
+    , mtl
+    , pathtype >=0.8
+    , resourcet >=1.2.4
+    , source-constraints
+    , tar >=0.5
     , tasty
     , tasty-hunit
     , template-haskell
-    , text ==1.2.*
-    , th-lift-instances ==0.1.*
-    , typed-process ==0.2.*
-    , unliftio ==0.2.*
-    , unliftio-core ==0.2.*
-    , unordered-containers ==0.2.*
-    , uuid ==1.3.*
+    , text
+    , th-lift-instances >=0.1
+    , typed-process >=0.2
+    , unliftio >=0.2
+    , unliftio-core >=0.2
+    , unordered-containers >=0.2
+    , uuid >=1.3
   if flag(development)
     ghc-options: -Werror -fplugin=SourceConstraints
     build-depends:

--- a/cbt/package.yaml
+++ b/cbt/package.yaml
@@ -8,28 +8,28 @@ synopsis:    A container backend toolkit
 
 dependencies:
 - base
-- bytestring           ^>= 0.10
-- conduit              ^>= 1.3.3
-- conversions          ^>= 0.0.3
-- cryptonite           >= 0.25 && <= 0.29
-- exceptions           ^>= 0.10
-- hashable             ^>= 1.3
-- mprelude             ^>= 0.2
-- mrio-log             ^>= 0.0.1
-- mrio-core            ^>= 0.0.1
-- mtl                  ^>= 2.2
-- pathtype             ^>= 0.8
-- resourcet            ^>= 1.2.4
-- source-constraints   ^>= 0.0.1
-- tar                  ^>= 0.5
+- bytestring
+- conduit              >= 1.3.3
+- conversions
+- cryptonite           >= 0.25
+- exceptions           >= 0.10
+- hashable             >= 1.3
+- mprelude             >= 0.2
+- mrio-log
+- mrio-core
+- mtl
+- pathtype             >= 0.8
+- resourcet            >= 1.2.4
+- source-constraints
+- tar                  >= 0.5
 - template-haskell
-- text                 ^>= 1.2
-- th-lift-instances    ^>= 0.1
-- typed-process        ^>= 0.2
-- unliftio             ^>= 0.2
-- unliftio-core        ^>= 0.2
-- unordered-containers ^>= 0.2
-- uuid                 ^>= 1.3
+- text
+- th-lift-instances    >= 0.1
+- typed-process        >= 0.2
+- unliftio             >= 0.2
+- unliftio-core        >= 0.2
+- unordered-containers >= 0.2
+- uuid                 >= 1.3
 
 default-extensions:
 - AllowAmbiguousTypes

--- a/cbt/test/stack-8.10-dependencies.txt
+++ b/cbt/test/stack-8.10-dependencies.txt
@@ -90,7 +90,7 @@ strict 0.4.0.1
 syb 0.7.2.1
 tagged 0.8.6.1
 tar 0.5.1.1
-tasty 1.3.1
+tasty 1.4.2
 tasty-expected-failure 0.12.3
 tasty-hunit 0.10.0.3
 tasty-mgolden 0.0.2

--- a/cbt/test/stack-9.0-dependencies.txt
+++ b/cbt/test/stack-9.0-dependencies.txt
@@ -91,7 +91,7 @@ strict 0.4.0.1
 syb 0.7.2.1
 tagged 0.8.6.1
 tar 0.5.1.1
-tasty 1.3.1
+tasty 1.4.2
 tasty-expected-failure 0.12.3
 tasty-hunit 0.10.0.3
 tasty-mgolden 0.0.2

--- a/conversions/conversions.cabal
+++ b/conversions/conversions.cabal
@@ -58,11 +58,11 @@ library
   ghc-options: -Wall -Wcompat -Werror -Widentities -Wimplicit-prelude -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-local-signatures -Wmissing-signatures -Wmonomorphism-restriction -Wredundant-constraints -fhide-source-paths -fplugin-opt=SourceConstraints:local:Blastschield -funbox-strict-fields -optP-Wno-nonportable-include-path
   build-depends:
       base
-    , bytestring ==0.10.*
-    , exceptions ==0.10.*
-    , mtl ==2.2.*
+    , bytestring
+    , exceptions
+    , mtl
     , template-haskell
-    , text ==1.2.*
+    , text
   if flag(development)
     ghc-options: -Werror -fplugin=SourceConstraints
     build-depends:
@@ -104,13 +104,13 @@ test-suite test
   ghc-options: -Wall -Wcompat -Werror -Widentities -Wimplicit-prelude -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-local-signatures -Wmissing-signatures -Wmonomorphism-restriction -Wredundant-constraints -fhide-source-paths -fplugin-opt=SourceConstraints:local:Blastschield -funbox-strict-fields -optP-Wno-nonportable-include-path -rtsopts -threaded -with-rtsopts=-N
   build-depends:
       base
-    , bytestring ==0.10.*
+    , bytestring
     , conversions
-    , devtools >=0.1.0 && <0.2
-    , exceptions ==0.10.*
-    , mtl ==2.2.*
+    , devtools
+    , exceptions
+    , mtl
     , template-haskell
-    , text ==1.2.*
+    , text
   if flag(development)
     ghc-options: -Werror -fplugin=SourceConstraints
     build-depends:

--- a/conversions/package.yaml
+++ b/conversions/package.yaml
@@ -9,11 +9,11 @@ version:    0.0.4
 
 dependencies:
 - base
-- bytestring         ^>= 0.10
-- exceptions         ^>= 0.10
-- mtl                ^>= 2.2
+- bytestring
+- exceptions
+- mtl
 - template-haskell
-- text               ^>= 1.2
+- text
 
 default-extensions:
 - AllowAmbiguousTypes
@@ -44,4 +44,4 @@ tests:
     <<: *test
     dependencies:
     - conversions
-    - devtools ^>= 0.1.0
+    - devtools

--- a/conversions/test/stack-8.10-dependencies.txt
+++ b/conversions/test/stack-8.10-dependencies.txt
@@ -74,7 +74,7 @@ stm 2.5.0.1
 strict 0.4.0.1
 syb 0.7.2.1
 tagged 0.8.6.1
-tasty 1.3.1
+tasty 1.4.2
 tasty-expected-failure 0.12.3
 tasty-hunit 0.10.0.3
 tasty-mgolden 0.0.2

--- a/conversions/test/stack-9.0-dependencies.txt
+++ b/conversions/test/stack-9.0-dependencies.txt
@@ -74,7 +74,7 @@ stm 2.5.0.0
 strict 0.4.0.1
 syb 0.7.2.1
 tagged 0.8.6.1
-tasty 1.3.1
+tasty 1.4.2
 tasty-expected-failure 0.12.3
 tasty-hunit 0.10.0.3
 tasty-mgolden 0.0.2

--- a/db-migrations/db-migrations.cabal
+++ b/db-migrations/db-migrations.cabal
@@ -53,28 +53,28 @@ library
   ghc-options: -Wall -Wcompat -Werror -Widentities -Wimplicit-prelude -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-local-signatures -Wmissing-signatures -Wmonomorphism-restriction -Wredundant-constraints -fhide-source-paths -fplugin-opt=SourceConstraints:local:Blastschield -funbox-strict-fields -optP-Wno-nonportable-include-path
   build-depends:
       base
-    , bytestring ==0.10.*
-    , containers ==0.6.*
-    , control-bool ==0.2.*
-    , conversions >=0.0.3 && <0.1
-    , cryptonite >=0.26 && <1
-    , dbt-postgresql-connection >=0.1.0 && <0.2
-    , hasql ==1.4.*
-    , hasql-th ==0.4.*
-    , hasql-transaction ==1.0.*
-    , memory >=0.15 && <0.16 || >=0.16 && <0.17
-    , mprelude ==0.2.*
-    , mrio-core >=0.0.1 && <0.1
-    , mtl ==2.2.*
-    , network ==3.1.*
-    , optparse-applicative >=0.15 && <0.16 || >=0.16 && <0.17
-    , pathtype ==0.8.*
-    , source-constraints >=0.0.1 && <0.1
+    , bytestring
+    , containers
+    , control-bool >=0.2
+    , conversions >=0.0.3
+    , cryptonite >=0.26
+    , dbt-postgresql-connection
+    , hasql >=1.4
+    , hasql-th >=0.4
+    , hasql-transaction >=1.0
+    , memory >=0.15
+    , mprelude >=0.2
+    , mrio-core >=0.0.1
+    , mtl
+    , network
+    , optparse-applicative >=0.15
+    , pathtype >=0.8
+    , source-constraints
     , template-haskell
-    , text ==1.2.*
-    , th-lift-instances ==0.1.*
-    , typed-process ==0.2.*
-    , unliftio ==0.2.*
+    , text
+    , th-lift-instances >=0.1
+    , typed-process >=0.2
+    , unliftio >=0.2
   if flag(development)
     ghc-options: -Werror -fplugin=SourceConstraints
     build-depends:
@@ -106,29 +106,29 @@ test-suite test
   ghc-options: -Wall -Wcompat -Werror -Widentities -Wimplicit-prelude -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-local-signatures -Wmissing-signatures -Wmonomorphism-restriction -Wredundant-constraints -fhide-source-paths -fplugin-opt=SourceConstraints:local:Blastschield -funbox-strict-fields -optP-Wno-nonportable-include-path -rtsopts -threaded -with-rtsopts=-N
   build-depends:
       base
-    , bytestring ==0.10.*
-    , containers ==0.6.*
-    , control-bool ==0.2.*
-    , conversions >=0.0.3 && <0.1
-    , cryptonite >=0.26 && <1
-    , dbt-postgresql-connection >=0.1.0 && <0.2
-    , devtools >=0.1.0 && <0.2
-    , hasql ==1.4.*
-    , hasql-th ==0.4.*
-    , hasql-transaction ==1.0.*
-    , memory >=0.15 && <0.16 || >=0.16 && <0.17
-    , mprelude ==0.2.*
-    , mrio-core >=0.0.1 && <0.1
-    , mtl ==2.2.*
-    , network ==3.1.*
-    , optparse-applicative >=0.15 && <0.16 || >=0.16 && <0.17
-    , pathtype ==0.8.*
-    , source-constraints >=0.0.1 && <0.1
+    , bytestring
+    , containers
+    , control-bool >=0.2
+    , conversions >=0.0.3
+    , cryptonite >=0.26
+    , dbt-postgresql-connection
+    , devtools
+    , hasql >=1.4
+    , hasql-th >=0.4
+    , hasql-transaction >=1.0
+    , memory >=0.15
+    , mprelude >=0.2
+    , mrio-core >=0.0.1
+    , mtl
+    , network
+    , optparse-applicative >=0.15
+    , pathtype >=0.8
+    , source-constraints
     , template-haskell
-    , text ==1.2.*
-    , th-lift-instances ==0.1.*
-    , typed-process ==0.2.*
-    , unliftio ==0.2.*
+    , text
+    , th-lift-instances >=0.1
+    , typed-process >=0.2
+    , unliftio >=0.2
   if flag(development)
     ghc-options: -Werror -fplugin=SourceConstraints
     build-depends:

--- a/db-migrations/package.yaml
+++ b/db-migrations/package.yaml
@@ -13,28 +13,28 @@ extra-doc-files:
 
 dependencies:
 - base
-- bytestring                ^>= 0.10
-- containers                ^>= 0.6
-- control-bool              ^>= 0.2
-- conversions               ^>= 0.0.3
-- cryptonite                >= 0.26 && < 1
-- dbt-postgresql-connection ^>= 0.1.0
-- hasql                     ^>= 1.4
-- hasql-th                  ^>= 0.4
-- hasql-transaction         ^>= 1.0
-- memory                    ^>= 0.15 || ^>= 0.16
-- mprelude                  ^>= 0.2
-- mrio-core                 ^>= 0.0.1
-- mtl                       ^>= 2.2
-- network                   ^>= 3.1
-- optparse-applicative      ^>= 0.15 || ^>= 0.16
-- pathtype                  ^>= 0.8
-- source-constraints        ^>= 0.0.1
+- bytestring
+- containers
+- control-bool              >= 0.2
+- conversions               >= 0.0.3
+- cryptonite                >= 0.26
+- dbt-postgresql-connection
+- hasql                     >= 1.4
+- hasql-th                  >= 0.4
+- hasql-transaction         >= 1.0
+- memory                    >= 0.15
+- mprelude                  >= 0.2
+- mrio-core                 >= 0.0.1
+- mtl
+- network
+- optparse-applicative      >= 0.15
+- pathtype                  >= 0.8
+- source-constraints
 - template-haskell
-- text                      ^>= 1.2
-- th-lift-instances         ^>= 0.1
-- typed-process             ^>= 0.2
-- unliftio                  ^>= 0.2
+- text
+- th-lift-instances         >= 0.1
+- typed-process             >= 0.2
+- unliftio                  >= 0.2
 
 default-extensions:
 - AllowAmbiguousTypes
@@ -53,5 +53,3 @@ default-extensions:
 tests:
   test:
     <<: *test
-    dependencies:
-    - devtools ^>= 0.1.0

--- a/db-migrations/test/stack-8.10-dependencies.txt
+++ b/db-migrations/test/stack-8.10-dependencies.txt
@@ -123,7 +123,7 @@ stm 2.5.0.1
 strict 0.4.0.1
 syb 0.7.2.1
 tagged 0.8.6.1
-tasty 1.3.1
+tasty 1.4.2
 tasty-expected-failure 0.12.3
 tasty-hunit 0.10.0.3
 tasty-mgolden 0.0.2

--- a/db-migrations/test/stack-9.0-dependencies.txt
+++ b/db-migrations/test/stack-9.0-dependencies.txt
@@ -124,7 +124,7 @@ stm 2.5.0.0
 strict 0.4.0.1
 syb 0.7.2.1
 tagged 0.8.6.1
-tasty 1.3.1
+tasty 1.4.2
 tasty-expected-failure 0.12.3
 tasty-hunit 0.10.0.3
 tasty-mgolden 0.0.2

--- a/devtools/devtools.cabal
+++ b/devtools/devtools.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.18
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 337452596ab02f6c221cfd985ad029d5a083bffb9300d1dc02459a694be204e6
+-- hash: 483fc9c4f6c96f4e7be1a90aa31b28d53d979d2931d3f691d078216a6683757b
 
 name:           devtools
 version:        0.1.0
@@ -52,17 +52,17 @@ library
       StrictData
   ghc-options: -Wall -Wcompat -Werror -Widentities -Wimplicit-prelude -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-local-signatures -Wmissing-signatures -Wmonomorphism-restriction -Wredundant-constraints -fhide-source-paths -fplugin-opt=SourceConstraints:local:Blastschield -funbox-strict-fields -optP-Wno-nonportable-include-path
   build-depends:
-      Diff >0.3 && <0.5
+      Diff >=0.4
     , base
-    , bytestring ==0.10.*
-    , cmdargs >=0.10.20 && <0.11
-    , filepath ==1.4.*
-    , hlint >3.1 && <4
-    , mprelude >=0.2.0 && <0.3
-    , tasty >=1.3.1 && <1.4
-    , tasty-mgolden >=0.0.1 && <0.1
-    , text ==1.2.*
-    , typed-process ==0.2.*
+    , bytestring
+    , cmdargs >=0.10.20
+    , filepath >=1.4
+    , hlint >=3.2
+    , mprelude
+    , tasty >=1.3.1
+    , tasty-mgolden >=0.0.1
+    , text
+    , typed-process >=0.2
   if flag(development)
     ghc-options: -Werror -fplugin=SourceConstraints
     build-depends:
@@ -87,18 +87,18 @@ test-suite test
       StrictData
   ghc-options: -Wall -Wcompat -Werror -Widentities -Wimplicit-prelude -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-local-signatures -Wmissing-signatures -Wmonomorphism-restriction -Wredundant-constraints -fhide-source-paths -fplugin-opt=SourceConstraints:local:Blastschield -funbox-strict-fields -optP-Wno-nonportable-include-path -rtsopts -threaded -with-rtsopts=-N
   build-depends:
-      Diff >0.3 && <0.5
+      Diff >=0.4
     , base
-    , bytestring ==0.10.*
-    , cmdargs >=0.10.20 && <0.11
+    , bytestring
+    , cmdargs >=0.10.20
     , devtools
-    , filepath ==1.4.*
-    , hlint >3.1 && <4
-    , mprelude >=0.2.0 && <0.3
-    , tasty >=1.3.1 && <1.4
-    , tasty-mgolden >=0.0.1 && <0.1
-    , text ==1.2.*
-    , typed-process ==0.2.*
+    , filepath >=1.4
+    , hlint >=3.2
+    , mprelude
+    , tasty >=1.3.1
+    , tasty-mgolden >=0.0.1
+    , text
+    , typed-process >=0.2
   if flag(development)
     ghc-options: -Werror -fplugin=SourceConstraints
     build-depends:

--- a/devtools/package.yaml
+++ b/devtools/package.yaml
@@ -12,17 +12,17 @@ description: |
 <<: *defaults
 
 dependencies:
-- Diff               > 0.3 && < 0.5
+- Diff          >= 0.4
 - base
-- bytestring         ^>= 0.10
-- cmdargs            ^>= 0.10.20
-- filepath           ^>= 1.4
-- hlint              > 3.1 && < 4
-- mprelude           ^>= 0.2.0
-- tasty              ^>= 1.3.1
-- tasty-mgolden      ^>= 0.0.1
-- text               ^>= 1.2
-- typed-process      ^>= 0.2
+- bytestring
+- cmdargs       >= 0.10.20
+- filepath      >= 1.4
+- hlint         >= 3.2
+- mprelude
+- tasty         >= 1.3.1
+- tasty-mgolden >= 0.0.1
+- text
+- typed-process >= 0.2
 
 extra-doc-files:
 - README.md

--- a/devtools/test/stack-8.10-dependencies.txt
+++ b/devtools/test/stack-8.10-dependencies.txt
@@ -73,7 +73,7 @@ stm 2.5.0.1
 strict 0.4.0.1
 syb 0.7.2.1
 tagged 0.8.6.1
-tasty 1.3.1
+tasty 1.4.2
 tasty-expected-failure 0.12.3
 tasty-hunit 0.10.0.3
 tasty-mgolden 0.0.2

--- a/devtools/test/stack-9.0-dependencies.txt
+++ b/devtools/test/stack-9.0-dependencies.txt
@@ -73,7 +73,7 @@ stm 2.5.0.0
 strict 0.4.0.1
 syb 0.7.2.1
 tagged 0.8.6.1
-tasty 1.3.1
+tasty 1.4.2
 tasty-expected-failure 0.12.3
 tasty-hunit 0.10.0.3
 tasty-mgolden 0.0.2

--- a/http-mclient/test/stack-8.10-dependencies.txt
+++ b/http-mclient/test/stack-8.10-dependencies.txt
@@ -90,7 +90,7 @@ strict 0.4.0.1
 syb 0.7.2.1
 symbols 0.3.0.0
 tagged 0.8.6.1
-tasty 1.3.1
+tasty 1.4.2
 tasty-expected-failure 0.12.3
 tasty-hunit 0.10.0.3
 tasty-mgolden 0.0.2

--- a/http-mclient/test/stack-9.0-dependencies.txt
+++ b/http-mclient/test/stack-9.0-dependencies.txt
@@ -90,7 +90,7 @@ strict 0.4.0.1
 syb 0.7.2.1
 symbols 0.3.0.0
 tagged 0.8.6.1
-tasty 1.3.1
+tasty 1.4.2
 tasty-expected-failure 0.12.3
 tasty-hunit 0.10.0.3
 tasty-mgolden 0.0.2

--- a/lambda-alb/test/stack-8.10-dependencies.txt
+++ b/lambda-alb/test/stack-8.10-dependencies.txt
@@ -88,7 +88,7 @@ streaming-commons 0.2.2.1
 strict 0.4.0.1
 syb 0.7.2.1
 tagged 0.8.6.1
-tasty 1.3.1
+tasty 1.4.2
 tasty-expected-failure 0.12.3
 tasty-hunit 0.10.0.3
 tasty-mgolden 0.0.2

--- a/lambda-alb/test/stack-9.0-dependencies.txt
+++ b/lambda-alb/test/stack-9.0-dependencies.txt
@@ -88,7 +88,7 @@ streaming-commons 0.2.2.1
 strict 0.4.0.1
 syb 0.7.2.1
 tagged 0.8.6.1
-tasty 1.3.1
+tasty 1.4.2
 tasty-expected-failure 0.12.3
 tasty-hunit 0.10.0.3
 tasty-mgolden 0.0.2

--- a/lambda-runtime/lambda-runtime.cabal
+++ b/lambda-runtime/lambda-runtime.cabal
@@ -81,7 +81,7 @@ library
     , http-types
     , mprelude
     , mtl
-    , optparse-applicative >=0.15 && <0.16 || >=0.16 && <0.17
+    , optparse-applicative >=0.15
     , text
   if flag(development)
     ghc-options: -Werror -fplugin=SourceConstraints
@@ -196,7 +196,7 @@ test-suite test
     , http-types
     , mprelude
     , mtl
-    , optparse-applicative >=0.15 && <0.16 || >=0.16 && <0.17
+    , optparse-applicative >=0.15
     , text
   if flag(development)
     ghc-options: -Werror -fplugin=SourceConstraints

--- a/lambda-runtime/package.yaml
+++ b/lambda-runtime/package.yaml
@@ -21,7 +21,7 @@ dependencies:
 - exceptions
 - mtl
 - mprelude
-- optparse-applicative ^>= 0.15 || ^>= 0.16
+- optparse-applicative >= 0.15
 - text
 
 flags:

--- a/lambda-runtime/test/stack-8.10-dependencies.txt
+++ b/lambda-runtime/test/stack-8.10-dependencies.txt
@@ -87,7 +87,7 @@ streaming-commons 0.2.2.1
 strict 0.4.0.1
 syb 0.7.2.1
 tagged 0.8.6.1
-tasty 1.3.1
+tasty 1.4.2
 tasty-expected-failure 0.12.3
 tasty-hunit 0.10.0.3
 tasty-mgolden 0.0.2

--- a/lambda-runtime/test/stack-9.0-dependencies.txt
+++ b/lambda-runtime/test/stack-9.0-dependencies.txt
@@ -87,7 +87,7 @@ streaming-commons 0.2.2.1
 strict 0.4.0.1
 syb 0.7.2.1
 tagged 0.8.6.1
-tasty 1.3.1
+tasty 1.4.2
 tasty-expected-failure 0.12.3
 tasty-hunit 0.10.0.3
 tasty-mgolden 0.0.2

--- a/lht/lht.cabal
+++ b/lht/lht.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: a4fdb3cc87fa215303297b870c455601ff6f731410fd5f843526282082d49812
+-- hash: 2d7bdc785ab438fcdd8df2578b5b43f2816a5ad356d3ad324cbc3f0a4fea5670
 
 name:           lht
 version:        0.0.1
@@ -63,29 +63,28 @@ library
   ghc-options: -Wall -Wcompat -Werror -Widentities -Wimplicit-prelude -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-local-signatures -Wmissing-signatures -Wmonomorphism-restriction -Wredundant-constraints -fhide-source-paths -fplugin-opt=SourceConstraints:local:Blastschield -funbox-strict-fields -optP-Wno-nonportable-include-path
   build-depends:
       base
-    , bytestring ==0.10.*
-    , cbt >=0.1.0 && <0.2
-    , conversions >=0.0.3 && <0.1
-    , directory ==1.3.*
-    , elf >=0.30 && <0.31 || >=0.31 && <0.32
-    , exceptions ==0.10.*
-    , http-types ==0.12.*
-    , mprelude ==0.2.*
-    , mrio-core >=0.0.1 && <0.1
-    , pathtype ==0.8.*
-    , source-constraints >=0.0.1 && <0.1
-    , tar ==0.5.*
+    , bytestring
+    , cbt
+    , conversions
+    , directory
+    , elf >=0.30
+    , exceptions
+    , http-types >=0.12
+    , mprelude >=0.2
+    , mrio-core
+    , pathtype >=0.8
+    , source-constraints
+    , tar >=0.5
     , template-haskell
-    , text ==1.2.*
-    , text-conversions ==0.3.*
-    , th-lift-instances ==0.1.*
-    , time ==1.9.*
-    , typed-process ==0.2.*
-    , unix ==2.7.*
-    , unliftio ==0.2.*
-    , unliftio-core ==0.2.*
-    , uuid ==1.3.*
-    , zip-archive ==0.4.*
+    , text
+    , th-lift-instances >=0.1
+    , time
+    , typed-process >=0.2
+    , unix
+    , unliftio >=0.2
+    , unliftio-core >=0.2
+    , uuid >=1.3
+    , zip-archive >=0.4
   if flag(development)
     ghc-options: -Werror -fplugin=SourceConstraints
     build-depends:
@@ -127,33 +126,32 @@ test-suite test
   ghc-options: -Wall -Wcompat -Werror -Widentities -Wimplicit-prelude -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-local-signatures -Wmissing-signatures -Wmonomorphism-restriction -Wredundant-constraints -fhide-source-paths -fplugin-opt=SourceConstraints:local:Blastschield -funbox-strict-fields -optP-Wno-nonportable-include-path -rtsopts -threaded -with-rtsopts=-N
   build-depends:
       base
-    , bytestring ==0.10.*
-    , cbt >=0.1.0 && <0.2
-    , conversions >=0.0.3 && <0.1
+    , bytestring
+    , cbt
+    , conversions
     , devtools
-    , directory ==1.3.*
-    , elf >=0.30 && <0.31 || >=0.31 && <0.32
-    , exceptions ==0.10.*
-    , http-types ==0.12.*
+    , directory
+    , elf >=0.30
+    , exceptions
+    , http-types >=0.12
     , lht
-    , mprelude ==0.2.*
-    , mrio-core >=0.0.1 && <0.1
-    , pathtype ==0.8.*
-    , source-constraints >=0.0.1 && <0.1
-    , tar ==0.5.*
-    , tasty ==1.3.*
-    , tasty-hunit ==0.10.*
+    , mprelude >=0.2
+    , mrio-core
+    , pathtype >=0.8
+    , source-constraints
+    , tar >=0.5
+    , tasty
+    , tasty-hunit
     , template-haskell
-    , text ==1.2.*
-    , text-conversions ==0.3.*
-    , th-lift-instances ==0.1.*
-    , time ==1.9.*
-    , typed-process ==0.2.*
-    , unix ==2.7.*
-    , unliftio ==0.2.*
-    , unliftio-core ==0.2.*
-    , uuid ==1.3.*
-    , zip-archive ==0.4.*
+    , text
+    , th-lift-instances >=0.1
+    , time
+    , typed-process >=0.2
+    , unix
+    , unliftio >=0.2
+    , unliftio-core >=0.2
+    , uuid >=1.3
+    , zip-archive >=0.4
   if flag(development)
     ghc-options: -Werror -fplugin=SourceConstraints
     build-depends:

--- a/lht/package.yaml
+++ b/lht/package.yaml
@@ -8,29 +8,28 @@ synopsis:    AWS Lambda haskell tool
 
 dependencies:
 - base
-- bytestring         ^>= 0.10
-- cbt                ^>= 0.1.0
-- conversions        ^>= 0.0.3
-- directory          ^>= 1.3
-- elf                ^>= 0.30 || ^>= 0.31
-- exceptions         ^>= 0.10
-- http-types         ^>= 0.12
-- mprelude           ^>= 0.2
-- mrio-core          ^>= 0.0.1
-- pathtype           ^>= 0.8
-- source-constraints ^>= 0.0.1
-- tar                ^>= 0.5
+- bytestring
+- cbt
+- conversions
+- directory
+- elf                >= 0.30
+- exceptions
+- http-types         >= 0.12
+- mprelude           >= 0.2
+- mrio-core
+- pathtype           >= 0.8
+- source-constraints
+- tar                >= 0.5
 - template-haskell
-- text               ^>= 1.2
-- text-conversions   ^>= 0.3
-- th-lift-instances  ^>= 0.1
-- time               ^>= 1.9
-- typed-process      ^>= 0.2
-- unix               ^>= 2.7
-- unliftio           ^>= 0.2
-- unliftio-core      ^>= 0.2
-- uuid               ^>= 1.3
-- zip-archive        ^>= 0.4
+- text
+- th-lift-instances  >= 0.1
+- time
+- typed-process      >= 0.2
+- unix
+- unliftio           >= 0.2
+- unliftio-core      >= 0.2
+- uuid               >= 1.3
+- zip-archive        >= 0.4
 
 default-extensions:
 - DataKinds
@@ -69,5 +68,5 @@ tests:
     dependencies:
     - devtools
     - lht
-    - tasty         ^>= 1.3
-    - tasty-hunit   ^>= 0.10
+    - tasty
+    - tasty-hunit

--- a/lht/test/stack-8.10-dependencies.txt
+++ b/lht/test/stack-8.10-dependencies.txt
@@ -12,8 +12,6 @@ base 4.14.3.0
 base-compat 0.11.2
 base-compat-batteries 0.11.2
 base-orphans 0.8.5
-base16-bytestring 1.0.1.0
-base64-bytestring 1.1.0.0
 basement 0.0.12
 bifunctors 5.5.11
 binary 0.8.8.0
@@ -46,7 +44,6 @@ distributive 0.6.2.1
 dlist 1.0
 elf 0.30
 entropy 0.4.1.6
-errors 2.3.0
 exceptions 0.10.4
 extra 1.7.9
 file-embed 0.0.15.0
@@ -88,7 +85,6 @@ random 1.2.0
 refact 0.3.0.2
 resourcet 1.2.4.3
 rts 1.0.1
-safe 0.3.19
 scientific 0.3.7.0
 semigroups 0.19.2
 source-constraints 0.0.2
@@ -99,14 +95,13 @@ strict 0.4.0.1
 syb 0.7.2.1
 tagged 0.8.6.1
 tar 0.5.1.1
-tasty 1.3.1
+tasty 1.4.2
 tasty-expected-failure 0.12.3
 tasty-hunit 0.10.0.3
 tasty-mgolden 0.0.2
 template-haskell 2.16.0.0
 terminfo 0.4.1.4
 text 1.2.4.1
-text-conversions 0.3.1
 th-abstraction 0.4.3.0
 th-lift 0.8.2
 th-lift-instances 0.1.18

--- a/lht/test/stack-9.0-dependencies.txt
+++ b/lht/test/stack-9.0-dependencies.txt
@@ -12,8 +12,6 @@ base 4.15.0.0
 base-compat 0.11.2
 base-compat-batteries 0.11.2
 base-orphans 0.8.5
-base16-bytestring 1.0.1.0
-base64-bytestring 1.2.1.0
 basement 0.0.12
 bifunctors 5.5.11
 binary 0.8.8.0
@@ -46,7 +44,6 @@ distributive 0.6.2.1
 dlist 1.0
 elf 0.31
 entropy 0.4.1.6
-errors 2.3.0
 exceptions 0.10.4
 extra 1.7.10
 file-embed 0.0.15.0
@@ -89,7 +86,6 @@ random 1.2.1
 refact 0.3.0.2
 resourcet 1.2.4.3
 rts 1.0
-safe 0.3.19
 scientific 0.3.7.0
 semigroups 0.19.2
 source-constraints 0.0.2
@@ -100,14 +96,13 @@ strict 0.4.0.1
 syb 0.7.2.1
 tagged 0.8.6.1
 tar 0.5.1.1
-tasty 1.3.1
+tasty 1.4.2
 tasty-expected-failure 0.12.3
 tasty-hunit 0.10.0.3
 tasty-mgolden 0.0.2
 template-haskell 2.17.0.0
 terminfo 0.4.1.4
 text 1.2.4.1
-text-conversions 0.3.1
 th-abstraction 0.4.3.0
 th-lift 0.8.2
 th-lift-instances 0.1.18

--- a/mprelude/mprelude.cabal
+++ b/mprelude/mprelude.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.18
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 5c4aed3651a55b3ccec94fde5cd37e74971f02bac1f5620451b1e846c843a923
+-- hash: 70dedde4fa76535ab2ce586496ddca3191a1466ca4510790a9a426124684609e
 
 name:           mprelude
 version:        0.2.1
@@ -63,9 +63,9 @@ library
   ghc-options: -Wall -Wcompat -Werror -Widentities -Wimplicit-prelude -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-local-signatures -Wmissing-signatures -Wmonomorphism-restriction -Wredundant-constraints -fhide-source-paths -fplugin-opt=SourceConstraints:local:Blastschield -funbox-strict-fields -optP-Wno-nonportable-include-path
   build-depends:
       base
-    , source-constraints >=0.0.2 && <0.1
-    , text ==1.2.*
-    , unliftio-core ==0.2.*
+    , source-constraints
+    , text
+    , unliftio-core >=0.2
   if flag(development)
     ghc-options: -Werror -fplugin=SourceConstraints
     build-depends:
@@ -104,9 +104,9 @@ test-suite test
   build-depends:
       base
     , devtools
-    , source-constraints >=0.0.2 && <0.1
-    , text ==1.2.*
-    , unliftio-core ==0.2.*
+    , source-constraints
+    , text
+    , unliftio-core >=0.2
   if flag(development)
     ghc-options: -Werror -fplugin=SourceConstraints
     build-depends:

--- a/mprelude/package.yaml
+++ b/mprelude/package.yaml
@@ -16,9 +16,9 @@ extra-doc-files: README.md
 
 dependencies:
 - base
-- source-constraints ^>= 0.0.2
-- text               ^>= 1.2
-- unliftio-core      ^>= 0.2
+- source-constraints
+- text
+- unliftio-core      >= 0.2
 
 default-extensions:
 - CPP

--- a/mrio-amazonka/mrio-amazonka.cabal
+++ b/mrio-amazonka/mrio-amazonka.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 3bb76cefeb6938a80efe7f7ab1f3a45dc6007e8e44ba044f3608daa24d092dca
+-- hash: 0b02c16a16c5995d6b746f12a2cf9ea1a0e3ebf2e8d3311b7736348153ba654c
 
 name:           mrio-amazonka
 version:        0.0.1
@@ -61,14 +61,14 @@ library
       ViewPatterns
   ghc-options: -Wall -Wcompat -Werror -Widentities -Wimplicit-prelude -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-local-signatures -Wmissing-signatures -Wmonomorphism-restriction -Wredundant-constraints -fhide-source-paths -fplugin-opt=SourceConstraints:local:Blastschield -funbox-strict-fields -optP-Wno-nonportable-include-path
   build-depends:
-      amazonka >=1.6.1 && <1.7
+      amazonka >=1.6.1 && <2
     , base
-    , conduit ==1.3.*
+    , conduit >=1.3
     , mrio-core
-    , mtl ==2.2.*
-    , resourcet >=1.2.4 && <1.3
+    , mtl
+    , resourcet >=1.2.4
     , source-constraints
-    , unliftio-core ==0.2.*
+    , unliftio-core >=0.2
   if flag(development)
     ghc-options: -Werror -fplugin=SourceConstraints
     build-depends:
@@ -112,16 +112,16 @@ test-suite test
       ViewPatterns
   ghc-options: -Wall -Wcompat -Werror -Widentities -Wimplicit-prelude -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-local-signatures -Wmissing-signatures -Wmonomorphism-restriction -Wredundant-constraints -fhide-source-paths -fplugin-opt=SourceConstraints:local:Blastschield -funbox-strict-fields -optP-Wno-nonportable-include-path -rtsopts -threaded -with-rtsopts=-N
   build-depends:
-      amazonka >=1.6.1 && <1.7
+      amazonka >=1.6.1 && <2
     , base
-    , conduit ==1.3.*
+    , conduit >=1.3
     , devtools
     , mrio-amazonka
     , mrio-core
-    , mtl ==2.2.*
-    , resourcet >=1.2.4 && <1.3
+    , mtl
+    , resourcet >=1.2.4
     , source-constraints
-    , unliftio-core ==0.2.*
+    , unliftio-core >=0.2
   if flag(development)
     ghc-options: -Werror -fplugin=SourceConstraints
     build-depends:

--- a/mrio-amazonka/package.yaml
+++ b/mrio-amazonka/package.yaml
@@ -8,14 +8,14 @@ version:    0.0.1
 <<: *defaults
 
 dependencies:
-- amazonka           ^>= 1.6.1
+- amazonka           >= 1.6.1 && < 2
 - base
-- conduit            ^>= 1.3
+- conduit            >= 1.3
 - mrio-core
-- mtl                ^>= 2.2
-- resourcet          ^>= 1.2.4
+- mtl
+- resourcet          >= 1.2.4
 - source-constraints
-- unliftio-core      ^>= 0.2
+- unliftio-core      >= 0.2
 
 tests:
   test:

--- a/mrio-amazonka/test/stack-8.10-dependencies.txt
+++ b/mrio-amazonka/test/stack-8.10-dependencies.txt
@@ -121,7 +121,7 @@ streaming-commons 0.2.2.1
 strict 0.4.0.1
 syb 0.7.2.1
 tagged 0.8.6.1
-tasty 1.3.1
+tasty 1.4.2
 tasty-expected-failure 0.12.3
 tasty-hunit 0.10.0.3
 tasty-mgolden 0.0.2

--- a/mrio-amazonka/test/stack-9.0-dependencies.txt
+++ b/mrio-amazonka/test/stack-9.0-dependencies.txt
@@ -123,7 +123,7 @@ streaming-commons 0.2.2.1
 strict 0.4.0.1
 syb 0.7.2.1
 tagged 0.8.6.1
-tasty 1.3.1
+tasty 1.4.2
 tasty-expected-failure 0.12.3
 tasty-hunit 0.10.0.3
 tasty-mgolden 0.0.2

--- a/mrio-core/test/stack-8.10-dependencies.txt
+++ b/mrio-core/test/stack-8.10-dependencies.txt
@@ -74,7 +74,7 @@ stm 2.5.0.1
 strict 0.4.0.1
 syb 0.7.2.1
 tagged 0.8.6.1
-tasty 1.3.1
+tasty 1.4.2
 tasty-expected-failure 0.12.3
 tasty-hunit 0.10.0.3
 tasty-mgolden 0.0.2

--- a/mrio-core/test/stack-9.0-dependencies.txt
+++ b/mrio-core/test/stack-9.0-dependencies.txt
@@ -74,7 +74,7 @@ stm 2.5.0.0
 strict 0.4.0.1
 syb 0.7.2.1
 tagged 0.8.6.1
-tasty 1.3.1
+tasty 1.4.2
 tasty-expected-failure 0.12.3
 tasty-hunit 0.10.0.3
 tasty-mgolden 0.0.2

--- a/mrio-log/mrio-log.cabal
+++ b/mrio-log/mrio-log.cabal
@@ -10,9 +10,9 @@ synopsis:       Minimal mrio based logger
 homepage:       https://github.com/mbj/mhs#readme
 bug-reports:    https://github.com/mbj/mhs/issues
 author:         Markus Schirp
-maintainer:     Markus Schirp mbj@schirp-dso.com
+maintainer:     markus@schirp-dso.com
 copyright:      2021 Markus Schirp
-license:        MIT
+license:        BSD3
 build-type:     Simple
 
 source-repository head

--- a/mrio-log/package.yaml
+++ b/mrio-log/package.yaml
@@ -3,9 +3,6 @@ _common/package: !include "../common/package.yaml"
 name:       mrio-log
 synopsis:   Minimal mrio based logger
 homepage:   https://github.com/mbj/mhs#readme
-maintainer: Markus Schirp mbj@schirp-dso.com
-copyright:  2021 Markus Schirp
-license:    MIT
 github:     mbj/mhs
 version:    0.0.1
 

--- a/mrio-log/test/stack-8.10-dependencies.txt
+++ b/mrio-log/test/stack-8.10-dependencies.txt
@@ -76,7 +76,7 @@ stm 2.5.0.1
 strict 0.4.0.1
 syb 0.7.2.1
 tagged 0.8.6.1
-tasty 1.3.1
+tasty 1.4.2
 tasty-expected-failure 0.12.3
 tasty-hunit 0.10.0.3
 tasty-mgolden 0.0.2

--- a/mrio-log/test/stack-9.0-dependencies.txt
+++ b/mrio-log/test/stack-9.0-dependencies.txt
@@ -76,7 +76,7 @@ stm 2.5.0.0
 strict 0.4.0.1
 syb 0.7.2.1
 tagged 0.8.6.1
-tasty 1.3.1
+tasty 1.4.2
 tasty-expected-failure 0.12.3
 tasty-hunit 0.10.0.3
 tasty-mgolden 0.0.2

--- a/oauth/test/stack-8.10-dependencies.txt
+++ b/oauth/test/stack-8.10-dependencies.txt
@@ -23,7 +23,6 @@ base 4.14.3.0
 base-compat 0.11.2
 base-compat-batteries 0.11.2
 base-orphans 0.8.5
-base16-bytestring 1.0.1.0
 base64-bytestring 1.1.0.0
 basement 0.0.12
 bifunctors 5.5.11
@@ -83,7 +82,6 @@ distributive 0.6.2.1
 dlist 1.0
 elf 0.30
 entropy 0.4.1.6
-errors 2.3.0
 exceptions 0.10.4
 extra 1.7.9
 file-embed 0.0.15.0
@@ -175,7 +173,6 @@ reflection 2.1.6
 resourcet 1.2.4.3
 retry 0.8.1.2
 rts 1.0.1
-safe 0.3.19
 scientific 0.3.7.0
 selective 0.4.2
 semigroupoids 5.3.5
@@ -195,7 +192,7 @@ syb 0.7.2.1
 symbols 0.3.0.0
 tagged 0.8.6.1
 tar 0.5.1.1
-tasty 1.3.1
+tasty 1.4.2
 tasty-expected-failure 0.12.3
 tasty-hunit 0.10.0.3
 tasty-mgolden 0.0.2
@@ -205,7 +202,6 @@ temporary 1.3
 terminfo 0.4.1.4
 text 1.2.4.1
 text-builder 0.6.6.3
-text-conversions 0.3.1
 text-latin1 0.3.1
 text-printer 0.5.0.1
 tf-random 0.5

--- a/oauth/test/stack-9.0-dependencies.txt
+++ b/oauth/test/stack-9.0-dependencies.txt
@@ -23,7 +23,6 @@ base 4.15.0.0
 base-compat 0.11.2
 base-compat-batteries 0.11.2
 base-orphans 0.8.5
-base16-bytestring 1.0.1.0
 base64-bytestring 1.2.1.0
 basement 0.0.12
 bifunctors 5.5.11
@@ -83,7 +82,6 @@ distributive 0.6.2.1
 dlist 1.0
 elf 0.31
 entropy 0.4.1.6
-errors 2.3.0
 exceptions 0.10.4
 extra 1.7.10
 file-embed 0.0.15.0
@@ -177,7 +175,6 @@ reflection 2.1.6
 resourcet 1.2.4.3
 retry 0.9.0.0
 rts 1.0
-safe 0.3.19
 scientific 0.3.7.0
 selective 0.4.2
 semigroupoids 5.3.6
@@ -197,7 +194,7 @@ syb 0.7.2.1
 symbols 0.3.0.0
 tagged 0.8.6.1
 tar 0.5.1.1
-tasty 1.3.1
+tasty 1.4.2
 tasty-expected-failure 0.12.3
 tasty-hunit 0.10.0.3
 tasty-mgolden 0.0.2
@@ -207,7 +204,6 @@ temporary 1.3
 terminfo 0.4.1.4
 text 1.2.4.1
 text-builder 0.6.6.3
-text-conversions 0.3.1
 text-latin1 0.3.1
 text-printer 0.5.0.1
 tf-random 0.5

--- a/openapi/openapi.cabal
+++ b/openapi/openapi.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 02c9c5f37dc974b6395f5a82ff2b7d7c0eb170c17c6ef4eb1d6b229a3bd302d2
+-- hash: 6f651b0821026a968bb18c6d5a43f955f37fbd479134d934b9b4c60f151ad65d
 
 name:           openapi
 version:        0.0.1
@@ -85,24 +85,23 @@ library
       TypeApplications
   ghc-options: -Wall -Wcompat -Werror -Widentities -Wimplicit-prelude -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-local-signatures -Wmissing-signatures -Wmonomorphism-restriction -Wredundant-constraints -fhide-source-paths -fplugin-opt=SourceConstraints:local:Blastschield -funbox-strict-fields -optP-Wno-nonportable-include-path
   build-depends:
-      aeson ==1.5.*
-    , attoparsec ==0.13.*
+      aeson >=1.5
+    , attoparsec >=0.13
     , base
-    , bytestring ==0.10.*
-    , conduit ==1.3.*
-    , containers ==0.6.*
-    , conversions >=0.0.3 && <0.1
-    , exceptions ==0.10.*
-    , http-types ==0.12.*
-    , mprelude >=0.2.0 && <0.3
-    , mtl ==2.2.*
-    , pathtype ==0.8.*
-    , scientific ==0.3.*
-    , source-constraints >=0.0.1 && <0.1
-    , text ==1.2.*
-    , text-conversions ==0.3.*
-    , unordered-containers ==0.2.*
-    , yaml ==0.11.*
+    , bytestring
+    , conduit >=1.3
+    , containers >=0.6
+    , conversions
+    , exceptions >=0.10
+    , http-types >=0.12
+    , mprelude
+    , mtl
+    , pathtype >=0.8
+    , scientific >=0.3
+    , source-constraints >=0.0.1
+    , text
+    , unordered-containers >=0.2
+    , yaml >=0.11
   if flag(development)
     ghc-options: -Werror -fplugin=SourceConstraints
     build-depends:
@@ -141,28 +140,27 @@ test-suite tasty
       TypeApplications
   ghc-options: -Wall -Wcompat -Werror -Widentities -Wimplicit-prelude -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-local-signatures -Wmissing-signatures -Wmonomorphism-restriction -Wredundant-constraints -fhide-source-paths -fplugin-opt=SourceConstraints:local:Blastschield -funbox-strict-fields -optP-Wno-nonportable-include-path -rtsopts -threaded -with-rtsopts=-N
   build-depends:
-      aeson ==1.5.*
-    , attoparsec ==0.13.*
+      aeson >=1.5
+    , attoparsec >=0.13
     , base
-    , bytestring ==0.10.*
-    , conduit ==1.3.*
-    , containers ==0.6.*
-    , conversions >=0.0.3 && <0.1
+    , bytestring
+    , conduit >=1.3
+    , containers >=0.6
+    , conversions
     , devtools
-    , exceptions ==0.10.*
-    , http-types ==0.12.*
-    , mprelude >=0.2.0 && <0.3
-    , mtl ==2.2.*
+    , exceptions >=0.10
+    , http-types >=0.12
+    , mprelude
+    , mtl
     , openapi
-    , pathtype ==0.8.*
-    , scientific ==0.3.*
-    , source-constraints >=0.0.1 && <0.1
+    , pathtype >=0.8
+    , scientific >=0.3
+    , source-constraints >=0.0.1
     , tasty
     , tasty-hunit
-    , text ==1.2.*
-    , text-conversions ==0.3.*
+    , text
     , unordered-containers
-    , yaml ==0.11.*
+    , yaml >=0.11
   if flag(development)
     ghc-options: -Werror -fplugin=SourceConstraints
     build-depends:

--- a/openapi/package.yaml
+++ b/openapi/package.yaml
@@ -9,24 +9,23 @@ maintainer:  mbj@schirp-dso.com
 <<: *defaults
 
 dependencies:
-- aeson                ^>= 1.5
-- attoparsec           ^>= 0.13
+- aeson                >= 1.5
+- attoparsec           >= 0.13
 - base
-- bytestring           ^>= 0.10
-- conduit              ^>= 1.3
-- containers           ^>= 0.6
-- conversions          ^>= 0.0.3
-- exceptions           ^>= 0.10
-- http-types           ^>= 0.12
-- mprelude             ^>= 0.2.0
-- mtl                  ^>= 2.2
-- pathtype             ^>= 0.8
-- scientific           ^>= 0.3
-- source-constraints   ^>= 0.0.1
-- text                 ^>= 1.2
-- text-conversions     ^>= 0.3
-- unordered-containers ^>= 0.2
-- yaml                 ^>= 0.11
+- bytestring
+- conduit              >= 1.3
+- containers           >= 0.6
+- conversions
+- exceptions           >= 0.10
+- http-types           >= 0.12
+- mprelude
+- mtl
+- pathtype             >= 0.8
+- scientific           >= 0.3
+- source-constraints   >= 0.0.1
+- text
+- unordered-containers >= 0.2
+- yaml                 >= 0.11
 
 default-extensions:
 - AllowAmbiguousTypes

--- a/openapi/test/stack-8.10-dependencies.txt
+++ b/openapi/test/stack-8.10-dependencies.txt
@@ -11,8 +11,6 @@ base 4.14.3.0
 base-compat 0.11.2
 base-compat-batteries 0.11.2
 base-orphans 0.8.5
-base16-bytestring 1.0.1.0
-base64-bytestring 1.1.0.0
 bifunctors 5.5.11
 binary 0.8.8.0
 bytestring 0.10.12.0
@@ -37,7 +35,6 @@ devtools 0.1.0
 directory 1.3.6.0
 distributive 0.6.2.1
 dlist 1.0
-errors 2.3.0
 exceptions 0.10.4
 extra 1.7.9
 file-embed 0.0.15.0
@@ -74,7 +71,6 @@ random 1.2.0
 refact 0.3.0.2
 resourcet 1.2.4.3
 rts 1.0.1
-safe 0.3.19
 scientific 0.3.7.0
 semigroups 0.19.2
 source-constraints 0.0.2
@@ -84,14 +80,13 @@ stm 2.5.0.1
 strict 0.4.0.1
 syb 0.7.2.1
 tagged 0.8.6.1
-tasty 1.3.1
+tasty 1.4.2
 tasty-expected-failure 0.12.3
 tasty-hunit 0.10.0.3
 tasty-mgolden 0.0.2
 template-haskell 2.16.0.0
 terminfo 0.4.1.4
 text 1.2.4.1
-text-conversions 0.3.1
 th-abstraction 0.4.3.0
 these 1.1.1.1
 time 1.9.3

--- a/openapi/test/stack-9.0-dependencies.txt
+++ b/openapi/test/stack-9.0-dependencies.txt
@@ -11,8 +11,6 @@ base 4.15.0.0
 base-compat 0.11.2
 base-compat-batteries 0.11.2
 base-orphans 0.8.5
-base16-bytestring 1.0.1.0
-base64-bytestring 1.2.1.0
 bifunctors 5.5.11
 binary 0.8.8.0
 bytestring 0.10.12.1
@@ -37,7 +35,6 @@ devtools 0.1.0
 directory 1.3.6.1
 distributive 0.6.2.1
 dlist 1.0
-errors 2.3.0
 exceptions 0.10.4
 extra 1.7.10
 file-embed 0.0.15.0
@@ -74,7 +71,6 @@ random 1.2.1
 refact 0.3.0.2
 resourcet 1.2.4.3
 rts 1.0
-safe 0.3.19
 scientific 0.3.7.0
 semigroups 0.19.2
 source-constraints 0.0.2
@@ -84,14 +80,13 @@ stm 2.5.0.0
 strict 0.4.0.1
 syb 0.7.2.1
 tagged 0.8.6.1
-tasty 1.3.1
+tasty 1.4.2
 tasty-expected-failure 0.12.3
 tasty-hunit 0.10.0.3
 tasty-mgolden 0.0.2
 template-haskell 2.17.0.0
 terminfo 0.4.1.4
 text 1.2.4.1
-text-conversions 0.3.1
 th-abstraction 0.4.3.0
 these 1.1.1.1
 time 1.9.3

--- a/pgt/package.yaml
+++ b/pgt/package.yaml
@@ -11,24 +11,23 @@ extra-source-files:
 
 dependencies:
 - base
-- bytestring                ^>= 0.10
-- containers                ^>= 0.6
-- conversions               ^>= 0.0.3
-- dbt-postgresql-connection ^>= 0.1.0
-- directory                 ^>= 1.3
-- filepath                  ^>= 1.4
-- mprelude                  ^>= 0.2.0
-- optparse-applicative      ^>= 0.15 || ^>= 0.16
-- ordered-containers        ^>= 0.2
-- pathtype                  ^>= 0.8.1
-- source-constraints        ^>= 0.0.1
-- tasty                     ^>= 1.3.1
-- tasty-mgolden             ^>= 0.0.1
-- text                      ^>= 1.2
-- text-conversions          ^>= 0.3
-- typed-process             ^>= 0.2
-- unix                      ^>= 2.7
-- unliftio                  ^>= 0.2
+- bytestring
+- containers                >= 0.6
+- conversions               >= 0.0.3
+- dbt-postgresql-connection >= 0.1.0
+- directory                 >= 1.3
+- filepath                  >= 1.4
+- mprelude
+- optparse-applicative      >= 0.15
+- ordered-containers        >= 0.2
+- pathtype                  >= 0.8.1
+- source-constraints
+- tasty                     >= 1.3.1
+- tasty-mgolden             >= 0.0.1
+- text
+- typed-process             >= 0.2
+- unix
+- unliftio                  >= 0.2
 
 executables:
   pgt:

--- a/pgt/pgt.cabal
+++ b/pgt/pgt.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 5aed59c06e71c9de286f256ed08e811b78851431b6b53082468d82ed4a6e9d42
+-- hash: 28cfc1b97c6aa70cf9ec4e194d429bfee192d75455b306dabddd5e3ebb9a09a4
 
 name:           pgt
 version:        0.0.1
@@ -73,24 +73,23 @@ library
   ghc-options: -Wall -Wcompat -Werror -Widentities -Wimplicit-prelude -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-local-signatures -Wmissing-signatures -Wmonomorphism-restriction -Wredundant-constraints -fhide-source-paths -fplugin-opt=SourceConstraints:local:Blastschield -funbox-strict-fields -optP-Wno-nonportable-include-path
   build-depends:
       base
-    , bytestring ==0.10.*
-    , containers ==0.6.*
-    , conversions >=0.0.3 && <0.1
-    , dbt-postgresql-connection >=0.1.0 && <0.2
-    , directory ==1.3.*
-    , filepath ==1.4.*
-    , mprelude >=0.2.0 && <0.3
-    , optparse-applicative >=0.15 && <0.16 || >=0.16 && <0.17
-    , ordered-containers ==0.2.*
-    , pathtype >=0.8.1 && <0.9
-    , source-constraints >=0.0.1 && <0.1
-    , tasty >=1.3.1 && <1.4
-    , tasty-mgolden >=0.0.1 && <0.1
-    , text ==1.2.*
-    , text-conversions ==0.3.*
-    , typed-process ==0.2.*
-    , unix ==2.7.*
-    , unliftio ==0.2.*
+    , bytestring
+    , containers >=0.6
+    , conversions >=0.0.3
+    , dbt-postgresql-connection >=0.1.0
+    , directory >=1.3
+    , filepath >=1.4
+    , mprelude
+    , optparse-applicative >=0.15
+    , ordered-containers >=0.2
+    , pathtype >=0.8.1
+    , source-constraints
+    , tasty >=1.3.1
+    , tasty-mgolden >=0.0.1
+    , text
+    , typed-process >=0.2
+    , unix
+    , unliftio >=0.2
   if flag(development)
     ghc-options: -Werror -fplugin=SourceConstraints
     build-depends:
@@ -134,25 +133,24 @@ executable pgt
   ghc-options: -Wall -Wcompat -Werror -Widentities -Wimplicit-prelude -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-local-signatures -Wmissing-signatures -Wmonomorphism-restriction -Wredundant-constraints -fhide-source-paths -fplugin-opt=SourceConstraints:local:Blastschield -funbox-strict-fields -optP-Wno-nonportable-include-path -rtsopts -threaded -with-rtsopts=-N
   build-depends:
       base
-    , bytestring ==0.10.*
-    , containers ==0.6.*
-    , conversions >=0.0.3 && <0.1
-    , dbt-postgresql-connection >=0.1.0 && <0.2
-    , directory ==1.3.*
-    , filepath ==1.4.*
-    , mprelude >=0.2.0 && <0.3
-    , optparse-applicative >=0.15 && <0.16 || >=0.16 && <0.17
-    , ordered-containers ==0.2.*
-    , pathtype >=0.8.1 && <0.9
+    , bytestring
+    , containers >=0.6
+    , conversions >=0.0.3
+    , dbt-postgresql-connection >=0.1.0
+    , directory >=1.3
+    , filepath >=1.4
+    , mprelude
+    , optparse-applicative >=0.15
+    , ordered-containers >=0.2
+    , pathtype >=0.8.1
     , pgt
-    , source-constraints >=0.0.1 && <0.1
-    , tasty >=1.3.1 && <1.4
-    , tasty-mgolden >=0.0.1 && <0.1
-    , text ==1.2.*
-    , text-conversions ==0.3.*
-    , typed-process ==0.2.*
-    , unix ==2.7.*
-    , unliftio ==0.2.*
+    , source-constraints
+    , tasty >=1.3.1
+    , tasty-mgolden >=0.0.1
+    , text
+    , typed-process >=0.2
+    , unix
+    , unliftio >=0.2
   if flag(development)
     ghc-options: -Werror -fplugin=SourceConstraints
     build-depends:
@@ -197,28 +195,27 @@ test-suite test
   ghc-options: -Wall -Wcompat -Werror -Widentities -Wimplicit-prelude -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-local-signatures -Wmissing-signatures -Wmonomorphism-restriction -Wredundant-constraints -fhide-source-paths -fplugin-opt=SourceConstraints:local:Blastschield -funbox-strict-fields -optP-Wno-nonportable-include-path -rtsopts -threaded -with-rtsopts=-N
   build-depends:
       base
-    , bytestring ==0.10.*
+    , bytestring
     , cbt
-    , containers ==0.6.*
-    , conversions >=0.0.3 && <0.1
-    , dbt-postgresql-connection >=0.1.0 && <0.2
+    , containers >=0.6
+    , conversions >=0.0.3
+    , dbt-postgresql-connection >=0.1.0
     , dbt-postgresql-container
     , devtools
-    , directory ==1.3.*
-    , filepath ==1.4.*
-    , mprelude >=0.2.0 && <0.3
-    , optparse-applicative >=0.15 && <0.16 || >=0.16 && <0.17
-    , ordered-containers ==0.2.*
-    , pathtype >=0.8.1 && <0.9
+    , directory >=1.3
+    , filepath >=1.4
+    , mprelude
+    , optparse-applicative >=0.15
+    , ordered-containers >=0.2
+    , pathtype >=0.8.1
     , pgt
-    , source-constraints >=0.0.1 && <0.1
-    , tasty >=1.3.1 && <1.4
-    , tasty-mgolden >=0.0.1 && <0.1
-    , text ==1.2.*
-    , text-conversions ==0.3.*
-    , typed-process ==0.2.*
-    , unix ==2.7.*
-    , unliftio ==0.2.*
+    , source-constraints
+    , tasty >=1.3.1
+    , tasty-mgolden >=0.0.1
+    , text
+    , typed-process >=0.2
+    , unix
+    , unliftio >=0.2
   if flag(development)
     ghc-options: -Werror -fplugin=SourceConstraints
     build-depends:

--- a/pgt/test/stack-8.10-dependencies.txt
+++ b/pgt/test/stack-8.10-dependencies.txt
@@ -13,8 +13,6 @@ base 4.14.3.0
 base-compat 0.11.2
 base-compat-batteries 0.11.2
 base-orphans 0.8.5
-base16-bytestring 1.0.1.0
-base64-bytestring 1.1.0.0
 basement 0.0.12
 bifunctors 5.5.11
 binary 0.8.8.0
@@ -59,7 +57,6 @@ directory 1.3.6.0
 distributive 0.6.2.1
 dlist 1.0
 entropy 0.4.1.6
-errors 2.3.0
 exceptions 0.10.4
 extra 1.7.9
 file-embed 0.0.15.0
@@ -110,7 +107,6 @@ random 1.2.0
 refact 0.3.0.2
 resourcet 1.2.4.3
 rts 1.0.1
-safe 0.3.19
 scientific 0.3.7.0
 semigroupoids 5.3.5
 semigroups 0.19.2
@@ -122,7 +118,7 @@ strict 0.4.0.1
 syb 0.7.2.1
 tagged 0.8.6.1
 tar 0.5.1.1
-tasty 1.3.1
+tasty 1.4.2
 tasty-expected-failure 0.12.3
 tasty-hunit 0.10.0.3
 tasty-mgolden 0.0.2
@@ -130,7 +126,6 @@ template-haskell 2.16.0.0
 terminfo 0.4.1.4
 text 1.2.4.1
 text-builder 0.6.6.3
-text-conversions 0.3.1
 text-latin1 0.3.1
 text-printer 0.5.0.1
 th-abstraction 0.4.3.0

--- a/pgt/test/stack-9.0-dependencies.txt
+++ b/pgt/test/stack-9.0-dependencies.txt
@@ -13,8 +13,6 @@ base 4.15.0.0
 base-compat 0.11.2
 base-compat-batteries 0.11.2
 base-orphans 0.8.5
-base16-bytestring 1.0.1.0
-base64-bytestring 1.2.1.0
 basement 0.0.12
 bifunctors 5.5.11
 binary 0.8.8.0
@@ -59,7 +57,6 @@ directory 1.3.6.1
 distributive 0.6.2.1
 dlist 1.0
 entropy 0.4.1.6
-errors 2.3.0
 exceptions 0.10.4
 extra 1.7.10
 file-embed 0.0.15.0
@@ -111,7 +108,6 @@ random 1.2.1
 refact 0.3.0.2
 resourcet 1.2.4.3
 rts 1.0
-safe 0.3.19
 scientific 0.3.7.0
 semigroupoids 5.3.6
 semigroups 0.19.2
@@ -123,7 +119,7 @@ strict 0.4.0.1
 syb 0.7.2.1
 tagged 0.8.6.1
 tar 0.5.1.1
-tasty 1.3.1
+tasty 1.4.2
 tasty-expected-failure 0.12.3
 tasty-hunit 0.10.0.3
 tasty-mgolden 0.0.2
@@ -131,7 +127,6 @@ template-haskell 2.17.0.0
 terminfo 0.4.1.4
 text 1.2.4.1
 text-builder 0.6.6.3
-text-conversions 0.3.1
 text-latin1 0.3.1
 text-printer 0.5.0.1
 th-abstraction 0.4.3.0

--- a/postgresql-connection/dbt-postgresql-connection.cabal
+++ b/postgresql-connection/dbt-postgresql-connection.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 66351494913b6fe826f3b8ee9b79a22fefce18f1e92c871097196f5ded72db6c
+-- hash: 7d6ba70da7c2ba40311b296443a475cc8fdb45b4813e59fdaca1ec29edf3b522
 
 name:           dbt-postgresql-connection
 version:        0.1.0
@@ -65,16 +65,16 @@ library
   ghc-options: -Wall -Wcompat -Werror -Widentities -Wimplicit-prelude -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-local-signatures -Wmissing-signatures -Wmonomorphism-restriction -Wredundant-constraints -fhide-source-paths -fplugin-opt=SourceConstraints:local:Blastschield -funbox-strict-fields -optP-Wno-nonportable-include-path
   build-depends:
       base
-    , bytestring ==0.10.*
-    , containers ==0.6.*
-    , conversions >=0.0.3 && <0.1
-    , hasql ==1.4.*
-    , mprelude >=0.2.0 && <0.3
-    , mrio-core >=0.0.1 && <0.1
-    , mtl ==2.2.*
-    , source-constraints >=0.0.2 && <0.1
-    , text ==1.2.*
-    , unliftio ==0.2.*
+    , bytestring
+    , containers
+    , conversions
+    , hasql >=1.4
+    , mprelude
+    , mrio-core
+    , mtl >=2.2
+    , source-constraints
+    , text
+    , unliftio >=0.2
   if flag(development)
     ghc-options: -Werror -fplugin=SourceConstraints
     build-depends:
@@ -119,18 +119,18 @@ test-suite test
   ghc-options: -Wall -Wcompat -Werror -Widentities -Wimplicit-prelude -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-local-signatures -Wmissing-signatures -Wmonomorphism-restriction -Wredundant-constraints -fhide-source-paths -fplugin-opt=SourceConstraints:local:Blastschield -funbox-strict-fields -optP-Wno-nonportable-include-path -rtsopts -threaded -with-rtsopts=-N
   build-depends:
       base
-    , bytestring ==0.10.*
-    , containers ==0.6.*
-    , conversions >=0.0.3 && <0.1
+    , bytestring
+    , containers
+    , conversions
     , dbt-postgresql-connection
     , devtools
-    , hasql ==1.4.*
-    , mprelude >=0.2.0 && <0.3
-    , mrio-core >=0.0.1 && <0.1
-    , mtl ==2.2.*
-    , source-constraints >=0.0.2 && <0.1
-    , text ==1.2.*
-    , unliftio ==0.2.*
+    , hasql >=1.4
+    , mprelude
+    , mrio-core
+    , mtl >=2.2
+    , source-constraints
+    , text
+    , unliftio >=0.2
   if flag(development)
     ghc-options: -Werror -fplugin=SourceConstraints
     build-depends:

--- a/postgresql-connection/package.yaml
+++ b/postgresql-connection/package.yaml
@@ -9,16 +9,16 @@ github:      mbj/dbt
 
 dependencies:
 - base
-- bytestring         ^>= 0.10
-- containers         ^>= 0.6
-- conversions        ^>= 0.0.3
-- hasql              ^>= 1.4
-- mprelude           ^>= 0.2.0
-- mrio-core          ^>= 0.0.1
-- mtl                ^>= 2.2
-- source-constraints ^>= 0.0.2
-- text               ^>= 1.2
-- unliftio           ^>= 0.2
+- bytestring
+- containers
+- conversions
+- hasql              >= 1.4
+- mprelude
+- mrio-core
+- mtl                >= 2.2
+- source-constraints
+- text
+- unliftio           >= 0.2
 
 tests:
   test:

--- a/postgresql-connection/test/stack-8.10-dependencies.txt
+++ b/postgresql-connection/test/stack-8.10-dependencies.txt
@@ -106,7 +106,7 @@ stm 2.5.0.1
 strict 0.4.0.1
 syb 0.7.2.1
 tagged 0.8.6.1
-tasty 1.3.1
+tasty 1.4.2
 tasty-expected-failure 0.12.3
 tasty-hunit 0.10.0.3
 tasty-mgolden 0.0.2

--- a/postgresql-connection/test/stack-9.0-dependencies.txt
+++ b/postgresql-connection/test/stack-9.0-dependencies.txt
@@ -106,7 +106,7 @@ stm 2.5.0.0
 strict 0.4.0.1
 syb 0.7.2.1
 tagged 0.8.6.1
-tasty 1.3.1
+tasty 1.4.2
 tasty-expected-failure 0.12.3
 tasty-hunit 0.10.0.3
 tasty-mgolden 0.0.2

--- a/postgresql-container/dbt-postgresql-container.cabal
+++ b/postgresql-container/dbt-postgresql-container.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: a13116fbe1679378403408b237fdda67f87afae0d0e3b56c45f8b8bd6c95181c
+-- hash: 1c9d9fd1c8b8c9412855adc9fb8dac966e653599b7fd3b149228aac9d49db47a
 
 name:           dbt-postgresql-container
 version:        0.1.0
@@ -64,26 +64,26 @@ library
   ghc-options: -Wall -Wcompat -Werror -Widentities -Wimplicit-prelude -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-local-signatures -Wmissing-signatures -Wmonomorphism-restriction -Wredundant-constraints -fhide-source-paths -fplugin-opt=SourceConstraints:local:Blastschield -funbox-strict-fields -optP-Wno-nonportable-include-path
   build-depends:
       base
-    , bytestring ==0.10.*
-    , cbt >=0.1.0 && <0.2
-    , containers ==0.6.*
-    , conversions >=0.0.3 && <0.1
-    , dbt-postgresql-connection >=0.1.0 && <0.2
-    , hasql ==1.4.*
-    , mprelude >=0.2.0 && <0.3
-    , mrio-core >=0.0.1 && <0.1
-    , mrio-log >=0.0.1 && <0.1
-    , mtl ==2.2.*
-    , network ==3.1.*
-    , optparse-applicative >=0.15 && <0.16 || >=0.16 && <0.17
-    , pathtype ==0.8.*
-    , source-constraints >=0.0.1 && <0.1
+    , bytestring
+    , cbt
+    , containers >=0.6
+    , conversions
+    , dbt-postgresql-connection
+    , hasql >=1.4
+    , mprelude
+    , mrio-core
+    , mrio-log
+    , mtl >=2.2
+    , network
+    , optparse-applicative >=0.15
+    , pathtype >=0.8
+    , source-constraints
     , template-haskell
-    , text ==1.2.*
-    , th-lift-instances ==0.1.*
-    , typed-process ==0.2.*
-    , unliftio ==0.2.*
-    , unliftio-core ==0.2.*
+    , text
+    , th-lift-instances >=0.1
+    , typed-process >=0.2
+    , unliftio >=0.2
+    , unliftio-core >=0.2
   if flag(development)
     ghc-options: -Werror -fplugin=SourceConstraints
     build-depends:
@@ -127,27 +127,27 @@ executable dbt
   ghc-options: -Wall -Wcompat -Werror -Widentities -Wimplicit-prelude -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-local-signatures -Wmissing-signatures -Wmonomorphism-restriction -Wredundant-constraints -fhide-source-paths -fplugin-opt=SourceConstraints:local:Blastschield -funbox-strict-fields -optP-Wno-nonportable-include-path -rtsopts -threaded -with-rtsopts=-N
   build-depends:
       base
-    , bytestring ==0.10.*
-    , cbt >=0.1.0 && <0.2
-    , containers ==0.6.*
-    , conversions >=0.0.3 && <0.1
-    , dbt-postgresql-connection >=0.1.0 && <0.2
+    , bytestring
+    , cbt
+    , containers >=0.6
+    , conversions
+    , dbt-postgresql-connection
     , dbt-postgresql-container
-    , hasql ==1.4.*
-    , mprelude >=0.2.0 && <0.3
-    , mrio-core >=0.0.1 && <0.1
-    , mrio-log >=0.0.1 && <0.1
-    , mtl ==2.2.*
-    , network ==3.1.*
-    , optparse-applicative >=0.15 && <0.16 || >=0.16 && <0.17
-    , pathtype ==0.8.*
-    , source-constraints >=0.0.1 && <0.1
+    , hasql >=1.4
+    , mprelude
+    , mrio-core
+    , mrio-log
+    , mtl >=2.2
+    , network
+    , optparse-applicative >=0.15
+    , pathtype >=0.8
+    , source-constraints
     , template-haskell
-    , text ==1.2.*
-    , th-lift-instances ==0.1.*
-    , typed-process ==0.2.*
-    , unliftio ==0.2.*
-    , unliftio-core ==0.2.*
+    , text
+    , th-lift-instances >=0.1
+    , typed-process >=0.2
+    , unliftio >=0.2
+    , unliftio-core >=0.2
   if flag(development)
     ghc-options: -Werror -fplugin=SourceConstraints
     build-depends:
@@ -192,30 +192,30 @@ test-suite test
   ghc-options: -Wall -Wcompat -Werror -Widentities -Wimplicit-prelude -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-local-signatures -Wmissing-signatures -Wmonomorphism-restriction -Wredundant-constraints -fhide-source-paths -fplugin-opt=SourceConstraints:local:Blastschield -funbox-strict-fields -optP-Wno-nonportable-include-path -rtsopts -threaded -with-rtsopts=-N
   build-depends:
       base
-    , bytestring ==0.10.*
-    , cbt >=0.1.0 && <0.2
-    , containers ==0.6.*
-    , conversions >=0.0.3 && <0.1
+    , bytestring
+    , cbt
+    , containers >=0.6
+    , conversions
     , dbt-postgresql-connection
     , dbt-postgresql-container
     , devtools >=0.1.0 && <0.2
-    , hasql ==1.4.*
-    , mprelude >=0.2.0 && <0.3
-    , mrio-core >=0.0.1 && <0.1
-    , mrio-log >=0.0.1 && <0.1
-    , mtl ==2.2.*
-    , network ==3.1.*
-    , optparse-applicative >=0.15 && <0.16 || >=0.16 && <0.17
-    , pathtype ==0.8.*
-    , source-constraints >=0.0.1 && <0.1
+    , hasql >=1.4
+    , mprelude
+    , mrio-core
+    , mrio-log
+    , mtl >=2.2
+    , network
+    , optparse-applicative >=0.15
+    , pathtype >=0.8
+    , source-constraints
     , tasty
     , tasty-mgolden
     , template-haskell
-    , text ==1.2.*
-    , th-lift-instances ==0.1.*
-    , typed-process ==0.2.*
-    , unliftio ==0.2.*
-    , unliftio-core ==0.2.*
+    , text
+    , th-lift-instances >=0.1
+    , typed-process >=0.2
+    , unliftio >=0.2
+    , unliftio-core >=0.2
   if flag(development)
     ghc-options: -Werror -fplugin=SourceConstraints
     build-depends:

--- a/postgresql-container/package.yaml
+++ b/postgresql-container/package.yaml
@@ -8,26 +8,26 @@ synopsis:    DBT Postgresql container tool
 
 dependencies:
 - base
-- bytestring                ^>= 0.10
-- cbt                       ^>= 0.1.0
-- containers                ^>= 0.6
-- conversions               ^>= 0.0.3
-- dbt-postgresql-connection ^>= 0.1.0
-- hasql                     ^>= 1.4
-- mprelude                  ^>= 0.2.0
-- mrio-log                  ^>= 0.0.1
-- mrio-core                 ^>= 0.0.1
-- mtl                       ^>= 2.2
-- network                   ^>= 3.1
-- optparse-applicative      ^>= 0.15 || ^>= 0.16
-- pathtype                  ^>= 0.8
-- source-constraints        ^>= 0.0.1
+- bytestring
+- cbt
+- containers                >= 0.6
+- conversions
+- dbt-postgresql-connection
+- hasql                     >= 1.4
+- mprelude
+- mrio-log
+- mrio-core
+- mtl                       >= 2.2
+- network
+- optparse-applicative      >= 0.15
+- pathtype                  >= 0.8
+- source-constraints
 - template-haskell
-- text                      ^>= 1.2
-- th-lift-instances         ^>= 0.1
-- typed-process             ^>= 0.2
-- unliftio                  ^>= 0.2
-- unliftio-core             ^>= 0.2
+- text
+- th-lift-instances         >= 0.1
+- typed-process             >= 0.2
+- unliftio                  >= 0.2
+- unliftio-core             >= 0.2
 
 library:
   source-dirs: src

--- a/postgresql-container/test/stack-8.10-dependencies.txt
+++ b/postgresql-container/test/stack-8.10-dependencies.txt
@@ -116,7 +116,7 @@ strict 0.4.0.1
 syb 0.7.2.1
 tagged 0.8.6.1
 tar 0.5.1.1
-tasty 1.3.1
+tasty 1.4.2
 tasty-expected-failure 0.12.3
 tasty-hunit 0.10.0.3
 tasty-mgolden 0.0.2

--- a/postgresql-container/test/stack-9.0-dependencies.txt
+++ b/postgresql-container/test/stack-9.0-dependencies.txt
@@ -117,7 +117,7 @@ strict 0.4.0.1
 syb 0.7.2.1
 tagged 0.8.6.1
 tar 0.5.1.1
-tasty 1.3.1
+tasty 1.4.2
 tasty-expected-failure 0.12.3
 tasty-hunit 0.10.0.3
 tasty-mgolden 0.0.2

--- a/source-constraints/package.yaml
+++ b/source-constraints/package.yaml
@@ -11,13 +11,13 @@ description: |
 <<: *defaults
 
 dependencies:
-- attoparsec ^>= 0.13
+- attoparsec >= 0.13
 - base
-- bytestring ^>= 0.10
-- filepath   ^>= 1.4
+- bytestring >= 0.10
+- filepath   >= 1.4
 - ghc        ^>= 8.10 || ^>= 9.0
-- syb        ^>= 0.7
-- text       ^>= 1.2
+- syb        >= 0.7
+- text
 
 extra-doc-files:
 - README.md

--- a/source-constraints/source-constraints.cabal
+++ b/source-constraints/source-constraints.cabal
@@ -57,13 +57,13 @@ library
       Strict
   ghc-options: -Wall -Wcompat -Widentities -Wimplicit-prelude -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-exported-signatures -Wmissing-local-signatures -Wmonomorphism-restriction
   build-depends:
-      attoparsec ==0.13.*
+      attoparsec >=0.13
     , base
-    , bytestring ==0.10.*
-    , filepath ==1.4.*
+    , bytestring >=0.10
+    , filepath >=1.4
     , ghc >=8.10 && <8.11 || >=9.0 && <9.1
-    , syb ==0.7.*
-    , text ==1.2.*
+    , syb >=0.7
+    , text
   if flag(development)
     ghc-options: -Werror
   else
@@ -87,17 +87,17 @@ test-suite hspec
       Strict
   ghc-options: -Wall -Wcompat -Widentities -Wimplicit-prelude -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-exported-signatures -Wmissing-local-signatures -Wmonomorphism-restriction -rtsopts -threaded -with-rtsopts=-N
   build-depends:
-      attoparsec ==0.13.*
+      attoparsec >=0.13
     , base
-    , bytestring ==0.10.*
-    , filepath ==1.4.*
+    , bytestring >=0.10
+    , filepath >=1.4
     , ghc >=8.10 && <8.11 || >=9.0 && <9.1
     , ghc-paths
     , heredoc
     , hspec
     , source-constraints
-    , syb ==0.7.*
-    , text ==1.2.*
+    , syb >=0.7
+    , text
   if flag(development)
     ghc-options: -Werror
   else

--- a/stack-8.10.yaml
+++ b/stack-8.10.yaml
@@ -6,7 +6,6 @@ extra-deps:
 - mprelude
 - postgresql-syntax-0.4@sha256:df8b65a33f4088eddad25cedbec814e5f34f8e8ae55065139b73bd6da0d66f21,4176
 - symbols-0.3.0.0@sha256:5d051bccbd4bcb33fa8ce076bd3cd2bacc90973682f7340976758947eaa128a9,964
-- tasty-1.3.1@sha256:01e35c97f7ee5ccbc28f21debea02a38cd010d53b4c3087f5677c5d06617a507,2520
 - stratosphere-0.58.0@sha256:f87e078696a13eaf35c08ef694803b3744d36ceeea4eecd6ac712577a9438245,142880
 - git: https://github.com/brendanhay/amazonka
   commit: 020bc7bde47bb235e448c76088dc44d6cec13e9b

--- a/stack-8.10.yaml.lock
+++ b/stack-8.10.yaml.lock
@@ -40,13 +40,6 @@ packages:
   original:
     hackage: symbols-0.3.0.0@sha256:5d051bccbd4bcb33fa8ce076bd3cd2bacc90973682f7340976758947eaa128a9,964
 - completed:
-    hackage: tasty-1.3.1@sha256:01e35c97f7ee5ccbc28f21debea02a38cd010d53b4c3087f5677c5d06617a507,2520
-    pantry-tree:
-      size: 1804
-      sha256: 6150ec5094fe321150b1263bc751c1a85b22be766053fb4648115d8c02b2064b
-  original:
-    hackage: tasty-1.3.1@sha256:01e35c97f7ee5ccbc28f21debea02a38cd010d53b4c3087f5677c5d06617a507,2520
-- completed:
     hackage: stratosphere-0.58.0@sha256:f87e078696a13eaf35c08ef694803b3744d36ceeea4eecd6ac712577a9438245,142880
     pantry-tree:
       size: 239498

--- a/stack-9.0.yaml
+++ b/stack-9.0.yaml
@@ -4,7 +4,6 @@ extra-deps:
 - mprelude
 - stratosphere-0.58.0@sha256:f87e078696a13eaf35c08ef694803b3744d36ceeea4eecd6ac712577a9438245,142880
 - symbols-0.3.0.0@sha256:5d051bccbd4bcb33fa8ce076bd3cd2bacc90973682f7340976758947eaa128a9,964
-- tasty-1.3.1@sha256:01e35c97f7ee5ccbc28f21debea02a38cd010d53b4c3087f5677c5d06617a507,2520
 - git: https://github.com/brendanhay/amazonka
   commit: 020bc7bde47bb235e448c76088dc44d6cec13e9b
   subdirs:

--- a/stack-9.0.yaml.lock
+++ b/stack-9.0.yaml.lock
@@ -26,13 +26,6 @@ packages:
   original:
     hackage: symbols-0.3.0.0@sha256:5d051bccbd4bcb33fa8ce076bd3cd2bacc90973682f7340976758947eaa128a9,964
 - completed:
-    hackage: tasty-1.3.1@sha256:01e35c97f7ee5ccbc28f21debea02a38cd010d53b4c3087f5677c5d06617a507,2520
-    pantry-tree:
-      size: 1804
-      sha256: 6150ec5094fe321150b1263bc751c1a85b22be766053fb4648115d8c02b2064b
-  original:
-    hackage: tasty-1.3.1@sha256:01e35c97f7ee5ccbc28f21debea02a38cd010d53b4c3087f5677c5d06617a507,2520
-- completed:
     subdir: amazonka
     name: amazonka
     version: 1.6.1

--- a/stack-deploy/package.yaml
+++ b/stack-deploy/package.yaml
@@ -8,39 +8,38 @@ license:     BSD3
 <<: *defaults
 
 dependencies:
-- aeson                   >= 1.4 || ^>= 1.5
-- aeson-pretty            ^>= 0.8
+- aeson                   >= 1.4
+- aeson-pretty            >= 0.8
 - amazonka
 - amazonka-cloudformation
 - amazonka-core
 - amazonka-s3
-- attoparsec              ^>= 0.13
+- attoparsec              >= 0.13
 - base
-- bytestring              ^>= 0.10
-- conduit                 ^>= 1.3
-- containers              ^>= 0.6
-- conversions             ^>= 0.0.3
-- exceptions              ^>= 0.10
-- filepath                ^>= 1.4
-- hashable                >= 1.2 && ^>= 1.3
-- http-types              ^>= 0.12
+- bytestring
+- conduit                 >= 1.3
+- containers              >= 0.6
+- conversions
+- exceptions              >= 0.10
+- filepath                >= 1.4
+- hashable                >= 1.2
+- http-types              >= 0.12
 - lens
-- mprelude                ^>= 0.2.0
-- mrio-core               ^>= 0.0.1
-- mrio-amazonka           ^>= 0.0.1
-- mtl                     ^>= 2.2
-- optparse-applicative    ^>= 0.14 || ^>= 0.15 || ^>= 0.16
-- random                  ^>= 1.1 || ^>= 1.2
-- source-constraints      ^>= 0.0.1
-- stratosphere            >= 0.58 && < 1
-- tasty                   ^>= 1.3
-- tasty-mgolden           ^>= 0.0.1
-- text                    ^>= 1.2
-- text-conversions        ^>= 0.3
-- time                    >= 1.8 && ^>= 1.9
-- unliftio                ^>= 0.2
-- unordered-containers    ^>= 0.2
-- vector                  ^>= 0.12
+- mprelude
+- mrio-core
+- mrio-amazonka
+- mtl
+- optparse-applicative    >= 0.14
+- random                  >= 1.1
+- source-constraints      >= 0.0.1
+- stratosphere            >= 0.58
+- tasty                   >= 1.3
+- tasty-mgolden           >= 0.0.1
+- text
+- time
+- unliftio                >= 0.2
+- unordered-containers    >= 0.2
+- vector                  >= 0.12
 
 tests:
   test:

--- a/stack-deploy/stack-deploy.cabal
+++ b/stack-deploy/stack-deploy.cabal
@@ -78,39 +78,38 @@ library
       ViewPatterns
   ghc-options: -Wall -Wcompat -Werror -Widentities -Wimplicit-prelude -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-local-signatures -Wmissing-signatures -Wmonomorphism-restriction -Wredundant-constraints -fhide-source-paths -fplugin-opt=SourceConstraints:local:Blastschield -funbox-strict-fields -optP-Wno-nonportable-include-path
   build-depends:
-      aeson >=1.4 || >=1.5 && <1.6
-    , aeson-pretty ==0.8.*
+      aeson >=1.4
+    , aeson-pretty >=0.8
     , amazonka
     , amazonka-cloudformation
     , amazonka-core
     , amazonka-s3
-    , attoparsec ==0.13.*
+    , attoparsec >=0.13
     , base
-    , bytestring ==0.10.*
-    , conduit ==1.3.*
-    , containers ==0.6.*
-    , conversions >=0.0.3 && <0.1
-    , exceptions ==0.10.*
-    , filepath ==1.4.*
-    , hashable >=1.2 && >=1.3 && <1.4
-    , http-types ==0.12.*
+    , bytestring
+    , conduit >=1.3
+    , containers >=0.6
+    , conversions
+    , exceptions >=0.10
+    , filepath >=1.4
+    , hashable >=1.2
+    , http-types >=0.12
     , lens
-    , mprelude >=0.2.0 && <0.3
-    , mrio-amazonka >=0.0.1 && <0.1
-    , mrio-core >=0.0.1 && <0.1
-    , mtl ==2.2.*
-    , optparse-applicative >=0.14 && <0.15 || >=0.15 && <0.16 || >=0.16 && <0.17
-    , random >=1.1 && <1.2 || >=1.2 && <1.3
-    , source-constraints >=0.0.1 && <0.1
-    , stratosphere >=0.58 && <1
-    , tasty ==1.3.*
-    , tasty-mgolden >=0.0.1 && <0.1
-    , text ==1.2.*
-    , text-conversions ==0.3.*
-    , time >=1.8 && >=1.9 && <1.10
-    , unliftio ==0.2.*
-    , unordered-containers ==0.2.*
-    , vector ==0.12.*
+    , mprelude
+    , mrio-amazonka
+    , mrio-core
+    , mtl
+    , optparse-applicative >=0.14
+    , random >=1.1
+    , source-constraints >=0.0.1
+    , stratosphere >=0.58
+    , tasty >=1.3
+    , tasty-mgolden >=0.0.1
+    , text
+    , time
+    , unliftio >=0.2
+    , unordered-containers >=0.2
+    , vector >=0.12
   if flag(development)
     ghc-options: -Werror -fplugin=SourceConstraints
     build-depends:
@@ -154,40 +153,39 @@ test-suite test
       ViewPatterns
   ghc-options: -Wall -Wcompat -Werror -Widentities -Wimplicit-prelude -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-local-signatures -Wmissing-signatures -Wmonomorphism-restriction -Wredundant-constraints -fhide-source-paths -fplugin-opt=SourceConstraints:local:Blastschield -funbox-strict-fields -optP-Wno-nonportable-include-path -rtsopts -threaded -with-rtsopts=-N
   build-depends:
-      aeson >=1.4 || >=1.5 && <1.6
-    , aeson-pretty ==0.8.*
+      aeson >=1.4
+    , aeson-pretty >=0.8
     , amazonka
     , amazonka-cloudformation
     , amazonka-core
     , amazonka-s3
-    , attoparsec ==0.13.*
+    , attoparsec >=0.13
     , base
-    , bytestring ==0.10.*
-    , conduit ==1.3.*
-    , containers ==0.6.*
-    , conversions >=0.0.3 && <0.1
+    , bytestring
+    , conduit >=1.3
+    , containers >=0.6
+    , conversions
     , devtools
-    , exceptions ==0.10.*
-    , filepath ==1.4.*
-    , hashable >=1.2 && >=1.3 && <1.4
-    , http-types ==0.12.*
+    , exceptions >=0.10
+    , filepath >=1.4
+    , hashable >=1.2
+    , http-types >=0.12
     , lens
-    , mprelude >=0.2.0 && <0.3
-    , mrio-amazonka >=0.0.1 && <0.1
-    , mrio-core >=0.0.1 && <0.1
-    , mtl ==2.2.*
-    , optparse-applicative >=0.14 && <0.15 || >=0.15 && <0.16 || >=0.16 && <0.17
-    , random >=1.1 && <1.2 || >=1.2 && <1.3
-    , source-constraints >=0.0.1 && <0.1
-    , stratosphere >=0.58 && <1
-    , tasty ==1.3.*
-    , tasty-mgolden >=0.0.1 && <0.1
-    , text ==1.2.*
-    , text-conversions ==0.3.*
-    , time >=1.8 && >=1.9 && <1.10
-    , unliftio ==0.2.*
-    , unordered-containers ==0.2.*
-    , vector ==0.12.*
+    , mprelude
+    , mrio-amazonka
+    , mrio-core
+    , mtl
+    , optparse-applicative >=0.14
+    , random >=1.1
+    , source-constraints >=0.0.1
+    , stratosphere >=0.58
+    , tasty >=1.3
+    , tasty-mgolden >=0.0.1
+    , text
+    , time
+    , unliftio >=0.2
+    , unordered-containers >=0.2
+    , vector >=0.12
   if flag(development)
     ghc-options: -Werror -fplugin=SourceConstraints
     build-depends:

--- a/stack-deploy/test/stack-8.10-dependencies.txt
+++ b/stack-deploy/test/stack-8.10-dependencies.txt
@@ -21,8 +21,6 @@ base 4.14.3.0
 base-compat 0.11.2
 base-compat-batteries 0.11.2
 base-orphans 0.8.5
-base16-bytestring 1.0.1.0
-base64-bytestring 1.1.0.0
 basement 0.0.12
 bifunctors 5.5.11
 binary 0.8.8.0
@@ -58,7 +56,6 @@ devtools 0.1.0
 directory 1.3.6.0
 distributive 0.6.2.1
 dlist 1.0
-errors 2.3.0
 exceptions 0.10.4
 extra 1.7.9
 file-embed 0.0.15.0
@@ -116,7 +113,6 @@ reflection 2.1.6
 resourcet 1.2.4.3
 retry 0.8.1.2
 rts 1.0.1
-safe 0.3.19
 scientific 0.3.7.0
 semigroupoids 5.3.5
 semigroups 0.19.2
@@ -131,14 +127,13 @@ streaming-commons 0.2.2.1
 strict 0.4.0.1
 syb 0.7.2.1
 tagged 0.8.6.1
-tasty 1.3.1
+tasty 1.4.2
 tasty-expected-failure 0.12.3
 tasty-hunit 0.10.0.3
 tasty-mgolden 0.0.2
 template-haskell 2.16.0.0
 terminfo 0.4.1.4
 text 1.2.4.1
-text-conversions 0.3.1
 th-abstraction 0.4.3.0
 th-compat 0.1.3
 these 1.1.1.1

--- a/stack-deploy/test/stack-9.0-dependencies.txt
+++ b/stack-deploy/test/stack-9.0-dependencies.txt
@@ -21,8 +21,6 @@ base 4.15.0.0
 base-compat 0.11.2
 base-compat-batteries 0.11.2
 base-orphans 0.8.5
-base16-bytestring 1.0.1.0
-base64-bytestring 1.2.1.0
 basement 0.0.12
 bifunctors 5.5.11
 binary 0.8.8.0
@@ -58,7 +56,6 @@ devtools 0.1.0
 directory 1.3.6.1
 distributive 0.6.2.1
 dlist 1.0
-errors 2.3.0
 exceptions 0.10.4
 extra 1.7.10
 file-embed 0.0.15.0
@@ -118,7 +115,6 @@ reflection 2.1.6
 resourcet 1.2.4.3
 retry 0.9.0.0
 rts 1.0
-safe 0.3.19
 scientific 0.3.7.0
 semigroupoids 5.3.6
 semigroups 0.19.2
@@ -133,14 +129,13 @@ streaming-commons 0.2.2.1
 strict 0.4.0.1
 syb 0.7.2.1
 tagged 0.8.6.1
-tasty 1.3.1
+tasty 1.4.2
 tasty-expected-failure 0.12.3
 tasty-hunit 0.10.0.3
 tasty-mgolden 0.0.2
 template-haskell 2.17.0.0
 terminfo 0.4.1.4
 text 1.2.4.1
-text-conversions 0.3.1
 th-abstraction 0.4.3.0
 th-compat 0.1.3
 these 1.1.1.1

--- a/tasty-mgolden/package.yaml
+++ b/tasty-mgolden/package.yaml
@@ -12,12 +12,12 @@ description: |
 <<: *defaults
 
 dependencies:
-- ansi-terminal ^>= 0.9 || ^>= 0.10 || ^>= 0.11
-- Diff          == 0.3.4 || ^>= 0.4
+- ansi-terminal >= 0.9
+- Diff          >= 0.3.4
 - base
-- filepath      ^>= 1.4.2
-- tasty         ^>= 1.3.1
-- text          ^>= 1.2
+- filepath
+- tasty         >= 1.3.1
+- text
 
 extra-doc-files: README.md
 

--- a/tasty-mgolden/tasty-mgolden.cabal
+++ b/tasty-mgolden/tasty-mgolden.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.18
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 0ead20e902a3d7f5642c4ee4e7416ad7ff8603dd5dfd0b240c9d8a6d1f341528
+-- hash: acffc899de8180677e80ca77e769e30d0ebe2aca1172366c42f023a7ba0a5aab
 
 name:           tasty-mgolden
 version:        0.0.2
@@ -50,12 +50,12 @@ library
       StrictData
   ghc-options: -Wall -Wcompat -Werror -Widentities -Wimplicit-prelude -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-local-signatures -Wmissing-signatures -Wmonomorphism-restriction -Wredundant-constraints -fhide-source-paths -fplugin-opt=SourceConstraints:local:Blastschield -funbox-strict-fields -optP-Wno-nonportable-include-path
   build-depends:
-      Diff ==0.3.4 || >=0.4 && <0.5
-    , ansi-terminal >=0.9 && <0.10 || >=0.10 && <0.11 || >=0.11 && <0.12
+      Diff >=0.3.4
+    , ansi-terminal >=0.9
     , base
-    , filepath >=1.4.2 && <1.5
-    , tasty >=1.3.1 && <1.4
-    , text ==1.2.*
+    , filepath
+    , tasty >=1.3.1
+    , text
   if flag(development)
     ghc-options: -Werror -fplugin=SourceConstraints
     build-depends:
@@ -76,15 +76,15 @@ executable tasty-mgolden-example
       ImplicitPrelude
   ghc-options: -Wall -Wcompat -Werror -Widentities -Wimplicit-prelude -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-local-signatures -Wmissing-signatures -Wmonomorphism-restriction -Wredundant-constraints -fhide-source-paths -fplugin-opt=SourceConstraints:local:Blastschield -funbox-strict-fields -optP-Wno-nonportable-include-path -rtsopts -threaded -with-rtsopts=-N -Wno-implicit-prelude
   build-depends:
-      Diff ==0.3.4 || >=0.4 && <0.5
-    , ansi-terminal >=0.9 && <0.10 || >=0.10 && <0.11 || >=0.11 && <0.12
+      Diff >=0.3.4
+    , ansi-terminal >=0.9
     , base
-    , filepath >=1.4.2 && <1.5
-    , tasty >=1.3.1 && <1.4
+    , filepath
+    , tasty >=1.3.1
     , tasty-expected-failure
     , tasty-hunit
     , tasty-mgolden
-    , text ==1.2.*
+    , text
   if flag(development)
     ghc-options: -Werror -fplugin=SourceConstraints
     build-depends:
@@ -105,17 +105,17 @@ test-suite golden
       StrictData
   ghc-options: -Wall -Wcompat -Werror -Widentities -Wimplicit-prelude -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-local-signatures -Wmissing-signatures -Wmonomorphism-restriction -Wredundant-constraints -fhide-source-paths -fplugin-opt=SourceConstraints:local:Blastschield -funbox-strict-fields -optP-Wno-nonportable-include-path -rtsopts -threaded -with-rtsopts=-N
   build-depends:
-      Diff ==0.3.4 || >=0.4 && <0.5
-    , ansi-terminal >=0.9 && <0.10 || >=0.10 && <0.11 || >=0.11 && <0.12
+      Diff >=0.3.4
+    , ansi-terminal >=0.9
     , base
     , directory
-    , filepath >=1.4.2 && <1.5
-    , tasty >=1.3.1 && <1.4
+    , filepath
+    , tasty >=1.3.1
     , tasty-expected-failure
     , tasty-hunit
     , tasty-mgolden
     , temporary
-    , text ==1.2.*
+    , text
     , typed-process
   if flag(development)
     ghc-options: -Werror -fplugin=SourceConstraints
@@ -139,13 +139,13 @@ test-suite hlint
       StrictData
   ghc-options: -Wall -Wcompat -Werror -Widentities -Wimplicit-prelude -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-local-signatures -Wmissing-signatures -Wmonomorphism-restriction -Wredundant-constraints -fhide-source-paths -fplugin-opt=SourceConstraints:local:Blastschield -funbox-strict-fields -optP-Wno-nonportable-include-path -rtsopts -threaded -with-rtsopts=-N
   build-depends:
-      Diff ==0.3.4 || >=0.4 && <0.5
-    , ansi-terminal >=0.9 && <0.10 || >=0.10 && <0.11 || >=0.11 && <0.12
+      Diff >=0.3.4
+    , ansi-terminal >=0.9
     , base
-    , filepath >=1.4.2 && <1.5
+    , filepath
     , hlint
-    , tasty >=1.3.1 && <1.4
-    , text ==1.2.*
+    , tasty >=1.3.1
+    , text
   if flag(development)
     ghc-options: -Werror -fplugin=SourceConstraints
     build-depends:


### PR DESCRIPTION
Current issues:

* I have no precognitive ability to know if the package I depend on will get
  a breaking change in a major release.
* Far more often I'm blockd by a too restrictive upper bound, rather than a
  compile issue in an API change.
* Having upper bounds, at the scale of the existing dependencies: Does not prevent
  from semantic errors creeping in after bumpbing the upper bound.

New policy:

* No version constraint on "core" (GHC packaged) packages.
* Only set upper bounds if its known already that new major releases will cause issues.
  (GHC, amazonka etc).
* Set lower bounds where its known to be valid.