### PR TITLE
Change to simplified mrio-log Action type

### DIFF
--- a/cbt/src/CBT/Environment.hs
+++ b/cbt/src/CBT/Environment.hs
@@ -23,7 +23,7 @@ type WithEnv env = (HasEnvironment env, Log.Env env)
 data Environment = Environment
   { debug     :: Bool
   , builds    :: IncrementalState ImageName ImageBuildError ()
-  , logAction :: Log.Action (RIO Environment)
+  , logAction :: Log.Action
   }
 
 class HasEnvironment env where

--- a/cbt/test/stack-9.0-dependencies.txt
+++ b/cbt/test/stack-9.0-dependencies.txt
@@ -66,7 +66,7 @@ memory 0.16.0
 mono-traversable 1.0.15.3
 mprelude 0.2.1
 mrio-core 0.0.1
-mrio-log 0.0.1
+mrio-log 0.0.2
 mtl 2.2.2
 network-info 0.2.0.10
 old-locale 1.0.0.7

--- a/lht/test/stack-9.0-dependencies.txt
+++ b/lht/test/stack-9.0-dependencies.txt
@@ -71,7 +71,7 @@ memory 0.16.0
 mono-traversable 1.0.15.3
 mprelude 0.2.1
 mrio-core 0.0.1
-mrio-log 0.0.1
+mrio-log 0.0.2
 mtl 2.2.2
 network-info 0.2.0.10
 old-locale 1.0.0.7

--- a/mrio-log/mrio-log.cabal
+++ b/mrio-log/mrio-log.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           mrio-log
-version:        0.0.1
+version:        0.0.2
 synopsis:       Minimal mrio based logger
 homepage:       https://github.com/mbj/mhs#readme
 bug-reports:    https://github.com/mbj/mhs/issues

--- a/mrio-log/package.yaml
+++ b/mrio-log/package.yaml
@@ -4,7 +4,7 @@ name:       mrio-log
 synopsis:   Minimal mrio based logger
 homepage:   https://github.com/mbj/mhs#readme
 github:     mbj/mhs
-version:    0.0.1
+version:    0.0.2
 
 <<: *defaults
 

--- a/mrio-log/test/Test.hs
+++ b/mrio-log/test/Test.hs
@@ -8,7 +8,7 @@ import qualified Devtools
 import qualified MRIO.Log as Log
 
 data Env = Env
-  { logAction :: Log.Action (RIO Env)
+  { logAction :: Log.Action
   , logBuffer :: IORef [Log.Message]
   , appName   :: Text
   }
@@ -39,7 +39,7 @@ testEnv = testCase "test app" $ do
      logBuffer <- newIORef []
 
      pure $ Env
-       { logAction = \message -> liftIO $ modifyIORef' logBuffer (message:)
+       { logAction = Log.Action $ \message -> liftIO $ modifyIORef' logBuffer (message:)
        , appName   = "Test App"
        , ..
        }

--- a/mrio-log/test/stack-9.0-dependencies.txt
+++ b/mrio-log/test/stack-9.0-dependencies.txt
@@ -56,7 +56,7 @@ libyaml 0.1.2
 mono-traversable 1.0.15.3
 mprelude 0.2.1
 mrio-core 0.0.1
-mrio-log 0.0.1
+mrio-log 0.0.2
 mtl 2.2.2
 old-locale 1.0.0.7
 optparse-applicative 0.16.1.0

--- a/pgt/test/stack-9.0-dependencies.txt
+++ b/pgt/test/stack-9.0-dependencies.txt
@@ -85,7 +85,7 @@ memory 0.16.0
 mono-traversable 1.0.15.3
 mprelude 0.2.1
 mrio-core 0.0.1
-mrio-log 0.0.1
+mrio-log 0.0.2
 mtl 2.2.2
 network 3.1.2.5
 network-info 0.2.0.10

--- a/postgresql-container/test/stack-9.0-dependencies.txt
+++ b/postgresql-container/test/stack-9.0-dependencies.txt
@@ -85,7 +85,7 @@ memory 0.16.0
 mono-traversable 1.0.15.3
 mprelude 0.2.1
 mrio-core 0.0.1
-mrio-log 0.0.1
+mrio-log 0.0.2
 mtl 2.2.2
 network 3.1.2.5
 network-info 0.2.0.10

--- a/xray/test/stack-9.0-dependencies.txt
+++ b/xray/test/stack-9.0-dependencies.txt
@@ -141,7 +141,7 @@ mono-traversable 1.0.15.3
 mprelude 0.2.1
 mrio-amazonka 0.0.1
 mrio-core 0.0.1
-mrio-log 0.0.1
+mrio-log 0.0.2
 mtl 2.2.2
 network 3.1.2.5
 network-info 0.2.0.10


### PR DESCRIPTION
* The reference to the RIO env was simply adding noise, it has
  proven to never be useful.