### PR TITLE
Fix oauth compliance

### DIFF
--- a/http-mclient/http-mclient.cabal
+++ b/http-mclient/http-mclient.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           http-mclient
-version:        0.0.3
+version:        0.0.4
 synopsis:       Minimal http-client
 description:    Minimal http-client built on top of http-client library
 category:       Web

--- a/http-mclient/package.yaml
+++ b/http-mclient/package.yaml
@@ -3,7 +3,7 @@ _common/package: !include "../common/package.yaml"
 name:                http-mclient
 synopsis:            Minimal http-client
 description:         Minimal http-client built on top of http-client library
-version:             0.0.3
+version:             0.0.4
 author:              gamsnjaga@gmail.com, epicallan.al@gmail.com
 maintainer:          gamsnjaga@gmail.com, epicallan.al@gmail.com, mbj@schirp-dso.com
 category:            Web

--- a/http-mclient/src/Network/HTTP/MClient.hs
+++ b/http-mclient/src/Network/HTTP/MClient.hs
@@ -81,7 +81,10 @@ decodeContentTypes contentTypes response
         (List.lookup contentType contentTypes)
 
 decodeJSON  :: JSON.FromJSON a => ResponseDecoder a
-decodeJSON = decodeContentType jsonContentType decodeJSONBody
+decodeJSON = decodeContentTypes
+ [ (jsonContentType,       decodeJSONBody)
+ , (jsonLegacyContentType, decodeJSONBody)
+ ]
 
 decodeJSONBody :: JSON.FromJSON a => ResponseDecoder a
 decodeJSONBody = left (BodyDecodeFailure . toText) . JSON.eitherDecode' . HTTP.responseBody
@@ -108,6 +111,9 @@ addHeader headerName value request =
 
 jsonContentType :: BS.ByteString
 jsonContentType = "application/json; charset=utf-8"
+
+jsonLegacyContentType :: BS.ByteString
+jsonLegacyContentType = "application/json"
 
 send
   :: Env env

--- a/http-mclient/test/stack-9.0-dependencies.txt
+++ b/http-mclient/test/stack-9.0-dependencies.txt
@@ -61,7 +61,7 @@ hlint 3.3.6
 hpc 0.6.1.0
 hscolour 1.24.4
 http-client 0.7.11
-http-mclient 0.0.3
+http-mclient 0.0.4
 http-types 0.12.3
 indexed-traversable 0.1.2
 indexed-traversable-instances 0.1.1

--- a/http-mclient/test/stack-9.2-dependencies.txt
+++ b/http-mclient/test/stack-9.2-dependencies.txt
@@ -61,7 +61,7 @@ hlint 3.3.5
 hpc 0.6.1.0
 hscolour 1.24.4
 http-client 0.7.11
-http-mclient 0.0.3
+http-mclient 0.0.4
 http-types 0.12.3
 indexed-traversable 0.1.2
 indexed-traversable-instances 0.1.1

--- a/oauth/oauth.cabal
+++ b/oauth/oauth.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           oauth
-version:        0.0.3
+version:        0.0.4
 synopsis:       Haskell Oauth library
 description:    Haskell Oauth library currently supporting only google auth
 category:       Oauth, Web

--- a/oauth/package.yaml
+++ b/oauth/package.yaml
@@ -3,7 +3,7 @@ _common/package: !include "../common/package.yaml"
 name:               oauth
 synopsis:           Haskell Oauth library
 description:        Haskell Oauth library currently supporting only google auth
-version:            0.0.3
+version:            0.0.4
 github:             mbj/mhs/oauth
 license:            BSD3
 author:             gamsnjaga@gmail.com

--- a/oauth/test/stack-9.0-dependencies.txt
+++ b/oauth/test/stack-9.0-dependencies.txt
@@ -62,7 +62,7 @@ hlint 3.3.6
 hpc 0.6.1.0
 hscolour 1.24.4
 http-client 0.7.11
-http-mclient 0.0.3
+http-mclient 0.0.4
 http-types 0.12.3
 indexed-traversable 0.1.2
 indexed-traversable-instances 0.1.1
@@ -76,7 +76,7 @@ mrio-core 0.0.1
 mtl 2.2.2
 network 3.1.2.7
 network-uri 2.6.4.1
-oauth 0.0.3
+oauth 0.0.4
 old-locale 1.0.0.7
 optparse-applicative 0.16.1.0
 parsec 3.1.14.0

--- a/oauth/test/stack-9.2-dependencies.txt
+++ b/oauth/test/stack-9.2-dependencies.txt
@@ -62,7 +62,7 @@ hlint 3.3.5
 hpc 0.6.1.0
 hscolour 1.24.4
 http-client 0.7.11
-http-mclient 0.0.3
+http-mclient 0.0.4
 http-types 0.12.3
 indexed-traversable 0.1.2
 indexed-traversable-instances 0.1.1
@@ -76,7 +76,7 @@ mrio-core 0.0.1
 mtl 2.2.2
 network 3.1.2.7
 network-uri 2.6.4.1
-oauth 0.0.3
+oauth 0.0.4
 old-locale 1.0.0.7
 optparse-applicative 0.16.1.0
 parsec 3.1.15.0


### PR DESCRIPTION
* The token endpoint actually needs to be called with an url encoded body.
* The responses can be either JSON with an implicit or an explicit charset.
  Which is de-facto true for any HTTP service that speaks JSON out there.