### PR TITLE
Add conversion instance for compartible bound-types

### DIFF
--- a/bounded/bounded.cabal
+++ b/bounded/bounded.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           bounded
-version:        0.0.2
+version:        0.0.3
 synopsis:       User definable Integral and Text bounded types
 homepage:       https://github.com/mbj/mhs#readme
 bug-reports:    https://github.com/mbj/mhs/issues

--- a/bounded/package.yaml
+++ b/bounded/package.yaml
@@ -3,7 +3,7 @@ _common/package: !include "../common/package.yaml"
 maintainer: Markus Schirp mbj@schirp-dso.com, Allan Lukwago <epicallan.al@gmail.com>
 name:       bounded
 synopsis:   User definable Integral and Text bounded types
-version:    0.0.2
+version:    0.0.3
 
 <<: *defaults
 

--- a/bounded/src/Data/Bounded/Integral.hs
+++ b/bounded/src/Data/Bounded/Integral.hs
@@ -46,6 +46,14 @@ instance
       minBound' :: Natural
       minBound' = convert @Natural $ minBound @bound
 
+instance
+  ( HasValidTypeRange '(min2, min1) (min2 <=? min1)
+  , HasValidTypeRange '(max1, max2) (max1 <=? max2)
+  , integral1 ~ integral2
+  )
+  => Conversion (BoundNumber' integral2 label2 '(min2, max2)) (BoundNumber' integral1 label1 '(min1, max1)) where
+    convert (BoundNumber value) = BoundNumber value
+
 instance (KnownNat min, KnownNat max, Conversion integral Natural )
   => Bounded (BoundNumber' integral label '(min, max)) where
   minBound = BoundNumber . convert @integral $ fromType @min @Natural

--- a/bounded/src/Data/Bounded/Text.hs
+++ b/bounded/src/Data/Bounded/Text.hs
@@ -93,6 +93,13 @@ instance
         min :: Natural
         min = fromType @min
 
+instance
+  ( HasValidTypeRange '(min2, min1) (min2 <=? min1)
+  , HasValidTypeRange '(max1, max2) (max1 <=? max2)
+  )
+  => Conversion (BoundText' label2 '(min2, max2)) (BoundText' label1 '(min1, max1)) where
+    convert (BoundText text) = BoundText text
+
 convertTruncate
   :: forall min max label . (KnownNat min, KnownNat max)
   => Text

--- a/bounded/test/stack-9.0-dependencies.txt
+++ b/bounded/test/stack-9.0-dependencies.txt
@@ -16,7 +16,7 @@ base-compat-batteries 0.11.2
 base-orphans 0.8.6
 bifunctors 5.5.11
 binary 0.8.8.0
-bounded 0.0.2
+bounded 0.0.3
 bytestring 0.10.12.1
 call-stack 0.4.0
 clock 0.8.3

--- a/bounded/test/stack-9.2-dependencies.txt
+++ b/bounded/test/stack-9.2-dependencies.txt
@@ -16,7 +16,7 @@ base-compat-batteries 0.12.1
 base-orphans 0.8.6
 bifunctors 5.5.11
 binary 0.8.9.0
-bounded 0.0.2
+bounded 0.0.3
 bytestring 0.11.3.0
 call-stack 0.4.0
 clock 0.8.3

--- a/lambda-alb/test/stack-9.0-dependencies.txt
+++ b/lambda-alb/test/stack-9.0-dependencies.txt
@@ -18,7 +18,7 @@ base64-bytestring 1.2.1.0
 bifunctors 5.5.11
 binary 0.8.8.0
 blaze-builder 0.4.2.2
-bounded 0.0.2
+bounded 0.0.3
 byteorder 1.0.4
 bytestring 0.10.12.1
 call-stack 0.4.0

--- a/lambda-alb/test/stack-9.2-dependencies.txt
+++ b/lambda-alb/test/stack-9.2-dependencies.txt
@@ -18,7 +18,7 @@ base64-bytestring 1.2.1.0
 bifunctors 5.5.11
 binary 0.8.9.0
 blaze-builder 0.4.2.2
-bounded 0.0.2
+bounded 0.0.3
 byteorder 1.0.4
 bytestring 0.11.3.0
 call-stack 0.4.0

--- a/lambda-runtime/test/stack-9.0-dependencies.txt
+++ b/lambda-runtime/test/stack-9.0-dependencies.txt
@@ -18,7 +18,7 @@ base64-bytestring 1.2.1.0
 bifunctors 5.5.11
 binary 0.8.8.0
 blaze-builder 0.4.2.2
-bounded 0.0.2
+bounded 0.0.3
 byteorder 1.0.4
 bytestring 0.10.12.1
 call-stack 0.4.0

--- a/lambda-runtime/test/stack-9.2-dependencies.txt
+++ b/lambda-runtime/test/stack-9.2-dependencies.txt
@@ -18,7 +18,7 @@ base64-bytestring 1.2.1.0
 bifunctors 5.5.11
 binary 0.8.9.0
 blaze-builder 0.4.2.2
-bounded 0.0.2
+bounded 0.0.3
 byteorder 1.0.4
 bytestring 0.11.3.0
 call-stack 0.4.0

--- a/oauth/test/stack-9.0-dependencies.txt
+++ b/oauth/test/stack-9.0-dependencies.txt
@@ -18,7 +18,7 @@ base64-bytestring 1.2.1.0
 bifunctors 5.5.11
 binary 0.8.8.0
 blaze-builder 0.4.2.2
-bounded 0.0.2
+bounded 0.0.3
 byteorder 1.0.4
 bytestring 0.10.12.1
 call-stack 0.4.0

--- a/oauth/test/stack-9.2-dependencies.txt
+++ b/oauth/test/stack-9.2-dependencies.txt
@@ -18,7 +18,7 @@ base64-bytestring 1.2.1.0
 bifunctors 5.5.11
 binary 0.8.9.0
 blaze-builder 0.4.2.2
-bounded 0.0.2
+bounded 0.0.3
 byteorder 1.0.4
 bytestring 0.11.3.0
 call-stack 0.4.0

--- a/pgt/test/stack-9.0-dependencies.txt
+++ b/pgt/test/stack-9.0-dependencies.txt
@@ -53,7 +53,7 @@ data-fix 0.3.2
 data-serializer 0.3.5
 data-textual 0.3.0.3
 dbt-postgresql-connection 0.1.0
-dbt-postgresql-container 0.1.0
+dbt-postgresql-container 0.1.1
 deepseq 1.4.5.0
 deferred-folds 0.9.18.1
 devtools 0.2.0

--- a/pgt/test/stack-9.2-dependencies.txt
+++ b/pgt/test/stack-9.2-dependencies.txt
@@ -53,7 +53,7 @@ data-fix 0.3.2
 data-serializer 0.3.5
 data-textual 0.3.0.3
 dbt-postgresql-connection 0.1.0
-dbt-postgresql-container 0.1.0
+dbt-postgresql-container 0.1.1
 deepseq 1.4.6.1
 deferred-folds 0.9.18.1
 devtools 0.2.0

--- a/xray/test/stack-9.0-dependencies.txt
+++ b/xray/test/stack-9.0-dependencies.txt
@@ -15,7 +15,7 @@ base-compat-batteries 0.11.2
 base-orphans 0.8.6
 bifunctors 5.5.11
 binary 0.8.8.0
-bounded 0.0.2
+bounded 0.0.3
 bytestring 0.10.12.1
 call-stack 0.4.0
 case-insensitive 1.2.1.0

--- a/xray/test/stack-9.2-dependencies.txt
+++ b/xray/test/stack-9.2-dependencies.txt
@@ -15,7 +15,7 @@ base-compat-batteries 0.12.1
 base-orphans 0.8.6
 bifunctors 5.5.11
 binary 0.8.9.0
-bounded 0.0.2
+bounded 0.0.3
 bytestring 0.11.3.0
 call-stack 0.4.0
 case-insensitive 1.2.1.0


### PR DESCRIPTION
Adds conversion instance for within range bound-texts & bound-number types  

Future follow-up tests that check the conversion instances work as expected. 