### PR TITLE
Remove implicit JSON decoding from ALB request

### DIFF
--- a/lambda-alb/example/Main.hs
+++ b/lambda-alb/example/Main.hs
@@ -6,7 +6,7 @@ import AWS.Lambda.Runtime.Prelude
 import qualified Network.HTTP.Types as HTTP
 import qualified System.IO          as IO
 
-handler :: Request Text -> IO Response
+handler :: Request -> IO Response
 handler event = do
   liftIO $ IO.hPutStr IO.stderr "Lambda Event started"
 

--- a/lambda-alb/lambda-alb.cabal
+++ b/lambda-alb/lambda-alb.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           lambda-alb
-version:        0.0.5
+version:        0.0.6
 synopsis:       AWS lambda ALB integration
 description:    AWS lambda ALB integration
 category:       Web,AWS

--- a/lambda-alb/package.yaml
+++ b/lambda-alb/package.yaml
@@ -3,7 +3,7 @@ _common/package: !include "../common/package.yaml"
 name:               lambda-alb
 synopsis:           AWS lambda ALB integration
 description:        AWS lambda ALB integration
-version:            0.0.5
+version:            0.0.6
 author:             epicallan.al@gmail.com, Markus Schirp, Makara digital
 maintainer:         epicallan.al@gmail.com, mbj@schirp-dso.com
 category:           Web,AWS

--- a/lambda-alb/test/stack-9.0-dependencies.txt
+++ b/lambda-alb/test/stack-9.0-dependencies.txt
@@ -67,7 +67,7 @@ indexed-traversable 0.1.2
 indexed-traversable-instances 0.1.1
 integer-logarithms 1.0.3.1
 iproute 1.7.12
-lambda-alb 0.0.5
+lambda-alb 0.0.6
 lambda-runtime 0.0.2
 libyaml 0.1.2
 mime-types 0.1.0.9

--- a/lambda-alb/test/stack-9.2-dependencies.txt
+++ b/lambda-alb/test/stack-9.2-dependencies.txt
@@ -67,7 +67,7 @@ indexed-traversable 0.1.2
 indexed-traversable-instances 0.1.1
 integer-logarithms 1.0.3.1
 iproute 1.7.12
-lambda-alb 0.0.5
+lambda-alb 0.0.6
 lambda-runtime 0.0.2
 libyaml 0.1.2
 mime-types 0.1.0.9


### PR DESCRIPTION
* The body gets send to us as a JSON string and this is supposed to be an 1:1 library.
* 1:1 libraries should not provide mapping abstractions, other layers can do this for us.