### PR TITLE
Add PGT CLI with linting & query-plan normalization

### DIFF
--- a/pgt/pgt.cabal
+++ b/pgt/pgt.cabal
@@ -44,6 +44,7 @@ library
   exposed-modules:
       PGT
       PGT.CLI
+      PGT.Output
       PGT.Output.Definition
       PGT.Output.Golden
       PGT.Output.Render

--- a/pgt/src/PGT/CLI.hs
+++ b/pgt/src/PGT/CLI.hs
@@ -38,10 +38,11 @@ parserInfo = wrapHelper subcommands
 
     subcommands =
       CLI.subparser
-        $  mkCommand "list"   runList
-        <> mkCommand "run"    runExamples
-        <> mkCommand "test"   runTests
-        <> mkCommand "update" runUpdates
+        $  mkCommand "list"      runList
+        <> mkCommand "run"       runExamples
+        <> mkCommand "test"      runTests
+        <> mkCommand "update"    runUpdates
+        <> mkCommand "update-v2" runUpdatesWithLinter
 
     mkCommand
       :: String

--- a/pgt/src/PGT/Output.hs
+++ b/pgt/src/PGT/Output.hs
@@ -1,0 +1,42 @@
+module PGT.Output
+  ( impureParse
+  , testTree
+  )
+where
+
+import Data.Attoparsec.Text (Parser)
+import Data.List.NonEmpty (NonEmpty(..))
+import PGT.Output.Render
+import PGT.Output.Test.QueryPlan (QueryStats)
+import PGT.Output.TestSuite (TestSuite)
+import PGT.Prelude
+
+import qualified Data.Attoparsec.Text as Text
+import qualified Data.List.NonEmpty   as NonEmpty
+import qualified Data.Text            as Text hiding (take)
+import qualified GHC.Err              as Err
+import qualified PGT.Output.Golden    as PGT
+import qualified PGT.Output.TestSuite as TestSuite
+import qualified System.Path          as Path
+import qualified Test.Tasty           as Tasty
+
+newtype Document a = Document (NonEmpty (TestSuite a))
+  deriving stock (Eq, Show)
+
+instance Render (Document QueryStats) where
+  render (Document outputs)
+    = (`Text.snoc` '\n')
+    . Text.intercalate "\n\n"
+    . NonEmpty.toList $ render <$> outputs
+
+impureParse :: Text -> Text
+impureParse = either Err.error identity . parse
+
+parse :: Text -> Either String Text
+parse = fmap render . Text.parseOnly parseDocument
+  where
+    parseDocument :: Parser (Document QueryStats)
+    parseDocument = Document . NonEmpty.fromList <$> Text.many1' TestSuite.parse
+
+testTree :: IO Tasty.TestTree
+testTree = PGT.mkDirGolden (Path.relDir "src/PGT/Output/examples") parse

--- a/pgt/src/PGT/Output/examples/success-with-multiple-test-suites.expected
+++ b/pgt/src/PGT/Output/examples/success-with-multiple-test-suites.expected
@@ -1,0 +1,36 @@
+                     View "public.users"
+        Column         |            Type             | Collation | Nullable | Default
+-----------------------+-----------------------------+-----------+----------+---------
+ user_exam1_id         | uuid                        |           |          |
+ user_exam1_created_at | timestamp without time zone |           |          |
+ account_id            | uuid                        |           |          |
+ user_example_text_123 | present_text_not_null[]     |           |          |
+
+-- First test-suite
+-- (2 rows)
+
+-[ RECORD 1 ]---------+------------------------------------------------
+exampleId1_id         | 00000000-0000-7000-0000-000000000138
+exampleId1_created_at | 1970-01-02 02:01:57
+-[ RECORD 1 ]---------+------------------------------------------------
+exampleId1_id         | 00000000-0000-7000-0000-000000000139
+exampleId1_created_at | 1970-02-02 02:01:57
+
+                     View "public.accounts"
+        Column         |            Type             | Collation | Nullable | Default
+-----------------------+-----------------------------+-----------+----------+---------
+ account_ex_id         | uuid                        |           |          |
+ acc_example_text_123  | present_text_not_null[]     |           |          |
+
+                    Composite type "user_type"
+       Column        |                Type                | Collation | Nullable | Default
+---------------------+------------------------------------+-----------+----------+---------
+ id                  | uuid_not_null                      |           |          |
+ created_at          | timestamptz_not_null               |           |          |
+
+-- Second test-suite
+-- (1 row)
+
+-[ RECORD 1 ]---------+------------------------------------------------
+exampleId1_id         | 00000000-0000-7000-0000-000000000138
+exampleId1_created_at | 1970-01-02 02:01:57

--- a/pgt/src/PGT/Output/examples/success-with-multiple-test-suites.expected.parsed
+++ b/pgt/src/PGT/Output/examples/success-with-multiple-test-suites.expected.parsed
@@ -1,0 +1,36 @@
+                     View "public.users"
+        Column         |            Type             | Collation | Nullable | Default
+-----------------------+-----------------------------+-----------+----------+---------
+ user_exam1_id         | uuid                        |           |          |
+ user_exam1_created_at | timestamp without time zone |           |          |
+ account_id            | uuid                        |           |          |
+ user_example_text_123 | present_text_not_null[]     |           |          |
+
+-- First test-suite
+-- (2 rows)
+
+-[ RECORD 1 ]---------+------------------------------------------------
+exampleId1_id         | 00000000-0000-7000-0000-000000000138
+exampleId1_created_at | 1970-01-02 02:01:57
+-[ RECORD 1 ]---------+------------------------------------------------
+exampleId1_id         | 00000000-0000-7000-0000-000000000139
+exampleId1_created_at | 1970-02-02 02:01:57
+
+                     View "public.accounts"
+        Column         |            Type             | Collation | Nullable | Default
+-----------------------+-----------------------------+-----------+----------+---------
+ account_ex_id         | uuid                        |           |          |
+ acc_example_text_123  | present_text_not_null[]     |           |          |
+
+                    Composite type "user_type"
+       Column        |                Type                | Collation | Nullable | Default
+---------------------+------------------------------------+-----------+----------+---------
+ id                  | uuid_not_null                      |           |          |
+ created_at          | timestamptz_not_null               |           |          |
+
+-- Second test-suite
+-- (1 row)
+
+-[ RECORD 1 ]---------+------------------------------------------------
+exampleId1_id         | 00000000-0000-7000-0000-000000000138
+exampleId1_created_at | 1970-01-02 02:01:57

--- a/pgt/src/PGT/Output/examples/success-with-single-test-suite.expected
+++ b/pgt/src/PGT/Output/examples/success-with-single-test-suite.expected
@@ -1,0 +1,17 @@
+                     View "public.users"
+        Column         |            Type             | Collation | Nullable | Default
+-----------------------+-----------------------------+-----------+----------+---------
+ user_exam1_id         | uuid                        |           |          |
+ user_exam1_created_at | timestamp without time zone |           |          |
+ account_id            | uuid                        |           |          |
+ user_example_text_123 | present_text_not_null[]     |           |          |
+
+-- First test-suite
+-- (2 rows)
+
+-[ RECORD 1 ]---------+------------------------------------------------
+exampleId1_id         | 00000000-0000-7000-0000-000000000138
+exampleId1_created_at | 1970-01-02 02:01:57
+-[ RECORD 1 ]---------+------------------------------------------------
+exampleId1_id         | 00000000-0000-7000-0000-000000000139
+exampleId1_created_at | 1970-02-02 02:01:57

--- a/pgt/src/PGT/Output/examples/success-with-single-test-suite.expected.parsed
+++ b/pgt/src/PGT/Output/examples/success-with-single-test-suite.expected.parsed
@@ -1,0 +1,17 @@
+                     View "public.users"
+        Column         |            Type             | Collation | Nullable | Default
+-----------------------+-----------------------------+-----------+----------+---------
+ user_exam1_id         | uuid                        |           |          |
+ user_exam1_created_at | timestamp without time zone |           |          |
+ account_id            | uuid                        |           |          |
+ user_example_text_123 | present_text_not_null[]     |           |          |
+
+-- First test-suite
+-- (2 rows)
+
+-[ RECORD 1 ]---------+------------------------------------------------
+exampleId1_id         | 00000000-0000-7000-0000-000000000138
+exampleId1_created_at | 1970-01-02 02:01:57
+-[ RECORD 1 ]---------+------------------------------------------------
+exampleId1_id         | 00000000-0000-7000-0000-000000000139
+exampleId1_created_at | 1970-02-02 02:01:57

--- a/pgt/test/Test.hs
+++ b/pgt/test/Test.hs
@@ -51,7 +51,7 @@ main = do
       liftIO . Tasty.defaultMain .
         Tasty.testGroup "" $
           [ Devtools.testTree $$(Devtools.readDependencies [Devtools.Target "pgt"])
-          , PGT.testTree config success
+          , PGT.testTree identity config success
           , testSharding
           ] <> outputTestTree
 

--- a/pgt/test/Test.hs
+++ b/pgt/test/Test.hs
@@ -12,6 +12,7 @@ import qualified DBT.Postgresql.Container as DBT
 import qualified Data.Text.IO             as Text
 import qualified Devtools
 import qualified PGT
+import qualified PGT.Output
 import qualified PGT.Output.Definition
 import qualified PGT.Output.Test
 import qualified PGT.Output.Test.Comments
@@ -44,6 +45,7 @@ main = do
           , PGT.Output.Test.Result.testTree
           , PGT.Output.Test.testTree
           , PGT.Output.TestSuite.testTree
+          , PGT.Output.testTree
           ]
 
       liftIO . Tasty.defaultMain .


### PR DESCRIPTION
* [x] Depends on #200 

Context: 

* The key idea is to parse the `.sql.expected` output into an AST we can validate while also extracting core signals from `query-plans`.

TODO: 

- [x] Add more tests 
- [x] Address current todo code comments 
- [x] Make `pgt update-v2` CLI live
- [x] split up into multiple commits