### PR TITLE
Change Test.Result.parseRows to parse empty rows

### DIFF
--- a/pgt/src/PGT/Output/Test.hs
+++ b/pgt/src/PGT/Output/Test.hs
@@ -70,7 +70,7 @@ validate test
         assertRowCount :: RowCount -> Either String ()
         assertRowCount commentRowCount = case result of
           Records records -> assertCount $ Result.recordsCount records
-          Rows    rows    -> assertCount $ Result.rowsCount rows
+          Rows    rows    -> assertCount $ rows.rowCount
           Empty           -> assertCount $ RowCount 0
           Error _         -> Left . ("expected a row result but found:\n\n" <>) . convert $ render result
           where

--- a/pgt/src/PGT/Output/Test/Result.hs
+++ b/pgt/src/PGT/Output/Test/Result.hs
@@ -68,17 +68,18 @@ instance Render Record where
 data RowResults = RowResults
   { columns  :: Text
   , rowCount :: RowCount
-  , rows     :: NonEmpty Text
+  , rows     :: [Text]
   }
   deriving stock (Eq, Show)
 
 instance Render RowResults where
   render RowResults{..}
-    = unlines @[]
-    [ convert columns
-    , unlines rows
-    , render rowCount
-    ]
+    = unlines $ convert columns : results
+    where
+      results :: [Text]
+      results = case rows of
+        [] -> [render rowCount]
+        _  -> [unlines rows, render rowCount]
 
 parse :: Parser Result
 parse =
@@ -204,8 +205,8 @@ parseRows = do
       columns <- parseLineChars
       pure $ padding <> columns
 
-    parseRowLines :: Parser (NonEmpty Text)
-    parseRowLines = NonEmpty.fromList  <$> Text.many1' parseRowLine
+    parseRowLines :: Parser [Text]
+    parseRowLines = Text.many' parseRowLine
       where
         parseRowLine :: Parser Text
         parseRowLine = do

--- a/pgt/src/PGT/Output/Test/Result/examples/zero-table-rows.expected
+++ b/pgt/src/PGT/Output/Test/Result/examples/zero-table-rows.expected
@@ -1,0 +1,3 @@
+ custody_subaccount_id | date | incremental_return | cumulative_return | balance_cents | total_invested_amount_cents
+-----------------------+------+--------------------+-------------------+---------------+-----------------------------
+(0 rows)

--- a/pgt/src/PGT/Output/Test/Result/examples/zero-table-rows.expected.parsed
+++ b/pgt/src/PGT/Output/Test/Result/examples/zero-table-rows.expected.parsed
@@ -1,0 +1,3 @@
+ custody_subaccount_id | date | incremental_return | cumulative_return | balance_cents | total_invested_amount_cents
+-----------------------+------+--------------------+-------------------+---------------+-----------------------------
+(0 rows)


### PR DESCRIPTION
* Adds support for parsing empty  `psql \g` formatted rows. 


* [x] Depends on #210

