### PR TITLE
Change to report line positions in error messages

### DIFF
--- a/pgt/src/PGT/Output/RowCount.hs
+++ b/pgt/src/PGT/Output/RowCount.hs
@@ -11,11 +11,11 @@ import Data.Tuple (fst)
 import Data.Word (Word16)
 import GHC.Real (properFraction)
 import PGT.Output.Render
+import PGT.Output.Text
 import PGT.Prelude
 
 import qualified Data.Attoparsec.Text as Text
 import qualified Data.Scientific      as Scientific
-import qualified GHC.Err              as Err
 
 newtype RowCount = RowCount Word16
   deriving stock (Eq, Show)
@@ -61,11 +61,9 @@ parse prefix = do
   where
     validateRowString :: RowCount -> Text -> Parser ()
     validateRowString rowCount@(RowCount count) string
-      | count == 1 && string /= "row"  = Err.error "expected (1 row) but found (1 rows)"
-      | count /= 1 && string /= "rows" = Err.error message
+      | count == 1 && string /= "row"  = errorP ("expected (1 row) but found (1 rows)" :: Text)
+      | count /= 1 && string /= "rows" = errorP message
       | otherwise                      = pure ()
       where
-        message :: String
-        message
-          = convert
-          $ "expected " <> render rowCount <> " but found (" <> showc count <> " row)"
+        message :: Text
+        message = "expected " <> render rowCount <> " but found (" <> showc count <> " row)"

--- a/pgt/src/PGT/Output/Test/Comments/examples/comment/failure-on-invalid-error-meta-comment.expected.parsed
+++ b/pgt/src/PGT/Output/Test/Comments/examples/comment/failure-on-invalid-error-meta-comment.expected.parsed
@@ -1,1 +1,1 @@
-expected row count or error text such as (1 row) or (ERROR) but found: (error)
+expected row count or error text such as (1 row) or (ERROR) but found: (error) at line: 1

--- a/pgt/src/PGT/Output/Test/Comments/examples/comments/failure-on-invalid-comments.expected.parsed
+++ b/pgt/src/PGT/Output/Test/Comments/examples/comments/failure-on-invalid-comments.expected.parsed
@@ -1,3 +1,3 @@
 expected valid test comment such as "-- my test comment" but received: 
 
-foo
+foo at line: 1

--- a/pgt/src/PGT/Output/Test/Comments/examples/comments/failure-on-invalid-error-meta-comment.expected.parsed
+++ b/pgt/src/PGT/Output/Test/Comments/examples/comments/failure-on-invalid-error-meta-comment.expected.parsed
@@ -1,3 +1,3 @@
 expected valid meta comment such as (ERROR) or (1 row) but received: 
 
--- (warning)
+-- (warning) at line: 2

--- a/pgt/src/PGT/Output/Test/Comments/examples/comments/failure-on-invalid-row-count-1.expected.parsed
+++ b/pgt/src/PGT/Output/Test/Comments/examples/comments/failure-on-invalid-row-count-1.expected.parsed
@@ -1,1 +1,1 @@
-expected (0 rows) but found (0 row)
+expected (0 rows) but found (0 row) at line: 2

--- a/pgt/src/PGT/Output/Test/Comments/examples/comments/failure-on-invalid-row-count-2.expected.parsed
+++ b/pgt/src/PGT/Output/Test/Comments/examples/comments/failure-on-invalid-row-count-2.expected.parsed
@@ -1,1 +1,1 @@
-expected (1 row) but found (1 rows)
+expected (1 row) but found (1 rows) at line: 2

--- a/pgt/src/PGT/Output/Test/Comments/examples/comments/failure-on-invalid-row-count-3.expected.parsed
+++ b/pgt/src/PGT/Output/Test/Comments/examples/comments/failure-on-invalid-row-count-3.expected.parsed
@@ -1,1 +1,1 @@
-expected (2 rows) but found (2 row)
+expected (2 rows) but found (2 row) at line: 2

--- a/pgt/src/PGT/Output/Test/Comments/examples/comments/failure-on-missing-meta-comment.expected.parsed
+++ b/pgt/src/PGT/Output/Test/Comments/examples/comments/failure-on-missing-meta-comment.expected.parsed
@@ -1,1 +1,1 @@
-expected a row-count comment such as (0 rows) or (ERROR) comment but received empty line
+expected a row-count comment such as (0 rows) or (ERROR) comment but received empty line at line: 1

--- a/pgt/src/PGT/Output/Test/Comments/examples/comments/failure-on-non-alpha-num-first-letter-comments.expected.parsed
+++ b/pgt/src/PGT/Output/Test/Comments/examples/comments/failure-on-non-alpha-num-first-letter-comments.expected.parsed
@@ -1,3 +1,3 @@
 Failed reading: expected a comment that starts with an alpha-num char but received:
 
-* comments
+* comments at line: 1

--- a/pgt/src/PGT/Output/Test/Comments/examples/comments/failure-on-partial-comment.expected.parsed
+++ b/pgt/src/PGT/Output/Test/Comments/examples/comments/failure-on-partial-comment.expected.parsed
@@ -1,1 +1,1 @@
-expected comment text after "--" but found none
+expected comment text after "--" but found none at line: 1

--- a/pgt/src/PGT/Output/Test/Comments/examples/comments/success-row-count-1.expected.parsed
+++ b/pgt/src/PGT/Output/Test/Comments/examples/comments/success-row-count-1.expected.parsed
@@ -1,1 +1,1 @@
-expected (0 rows) but found (0 row)
+expected (0 rows) but found (0 row) at line: 2

--- a/pgt/src/PGT/Output/Test/examples/failure-on-extra-line-after-comments.expected.parsed
+++ b/pgt/src/PGT/Output/Test/examples/failure-on-extra-line-after-comments.expected.parsed
@@ -1,1 +1,1 @@
-found 2 empty lines after test comments instead of 1
+found 2 empty lines after test comments instead of 1 at line: 3

--- a/pgt/src/PGT/Output/Test/examples/failure-on-invalid-error-comment-1.expected.parsed
+++ b/pgt/src/PGT/Output/Test/examples/failure-on-invalid-error-comment-1.expected.parsed
@@ -2,4 +2,4 @@ expected an error result but found:
 
 -[ RECORD 1 ]---------+------------------------------------------------
 exampleId1_id         | 00000000-0000-7000-0000-000000000138
-exampleId1_created_at | 1970-01-02 02:01:57
+exampleId1_created_at | 1970-01-02 02:01:57 at line: 6

--- a/pgt/src/PGT/Output/Test/examples/failure-on-invalid-error-comment-2.expected.parsed
+++ b/pgt/src/PGT/Output/Test/examples/failure-on-invalid-error-comment-2.expected.parsed
@@ -1,3 +1,3 @@
 expected an error result but found:
 
-(0 rows)
+(0 rows) at line: 4

--- a/pgt/src/PGT/Output/Test/examples/failure-on-invalid-error-result.expected.parsed
+++ b/pgt/src/PGT/Output/Test/examples/failure-on-invalid-error-result.expected.parsed
@@ -1,3 +1,3 @@
 expected a row result but found:
 
-ERROR:  domain create_example_amount1 does not allow null values
+ERROR:  domain create_example_amount1 does not allow null values at line: 4

--- a/pgt/src/PGT/Output/Test/examples/failure-on-invalid-records-count.expected.parsed
+++ b/pgt/src/PGT/Output/Test/examples/failure-on-invalid-records-count.expected.parsed
@@ -1,1 +1,1 @@
-expected (1 row) comment but received (2 rows)
+expected (1 row) comment but received (2 rows) at line: 6

--- a/pgt/src/PGT/Output/Test/examples/failure-on-invalid-rows-count.expected.parsed
+++ b/pgt/src/PGT/Output/Test/examples/failure-on-invalid-rows-count.expected.parsed
@@ -1,1 +1,1 @@
-expected (2 rows) comment but received (4 rows)
+expected (2 rows) comment but received (4 rows) at line: 8

--- a/pgt/src/PGT/Output/Test/examples/failure-on-invalid-zero-rows-count.expected.parsed
+++ b/pgt/src/PGT/Output/Test/examples/failure-on-invalid-zero-rows-count.expected.parsed
@@ -1,1 +1,1 @@
-expected (0 rows) comment but received (2 rows)
+expected (0 rows) comment but received (2 rows) at line: 4

--- a/pgt/src/PGT/Output/Test/examples/failure-on-missing-line-after-comments.expected.parsed
+++ b/pgt/src/PGT/Output/Test/examples/failure-on-missing-line-after-comments.expected.parsed
@@ -1,1 +1,1 @@
-found 0 empty lines after test comments instead of 1
+found 0 empty lines after test comments instead of 1 at line: 3

--- a/pgt/src/PGT/Output/TestSuite/examples/failure-on-empty-content.expected.parsed
+++ b/pgt/src/PGT/Output/TestSuite/examples/failure-on-empty-content.expected.parsed
@@ -1,1 +1,1 @@
-Failed reading: expected a valid test or database object definition but found none
+Failed reading: expected a valid test or database object definition but found none at line: 1

--- a/pgt/src/PGT/Output/TestSuite/examples/failure-on-empty-line-before-tests-without-definitions.expected.parsed
+++ b/pgt/src/PGT/Output/TestSuite/examples/failure-on-empty-line-before-tests-without-definitions.expected.parsed
@@ -1,1 +1,1 @@
-Failed reading: expected database object definition or test but found an empty line
+Failed reading: expected database object definition or test but found an empty line at line: 1

--- a/pgt/src/PGT/Output/TestSuite/examples/failure-on-extra-line-after-definitions.expected.parsed
+++ b/pgt/src/PGT/Output/TestSuite/examples/failure-on-extra-line-after-definitions.expected.parsed
@@ -1,1 +1,1 @@
-Failed reading: expected database object definition or test but found an empty line
+Failed reading: expected database object definition or test but found an empty line at line: 5

--- a/pgt/src/PGT/Output/TestSuite/examples/failure-on-extra-line-after-error-results.expected.parsed
+++ b/pgt/src/PGT/Output/TestSuite/examples/failure-on-extra-line-after-error-results.expected.parsed
@@ -1,1 +1,1 @@
-found 2 empty lines after an error result instead of 1
+found 2 empty lines after an error result instead of 1 at line: 4

--- a/pgt/src/PGT/Output/TestSuite/examples/failure-on-missing-2-empty-lines-tests-separator.expected.parsed
+++ b/pgt/src/PGT/Output/TestSuite/examples/failure-on-missing-2-empty-lines-tests-separator.expected.parsed
@@ -1,1 +1,1 @@
-found 1 empty lines after a test instead of 2
+found 1 empty lines after a test instead of 2 at line: 44

--- a/pgt/src/PGT/Output/TestSuite/examples/failure-on-unexpected-text-after-defintion.expected.parsed
+++ b/pgt/src/PGT/Output/TestSuite/examples/failure-on-unexpected-text-after-defintion.expected.parsed
@@ -1,3 +1,4 @@
 Failed reading: expected a test after database object definitions but found: 
 
 foo bar
+ at line: 7

--- a/pgt/src/PGT/Output/Text.hs
+++ b/pgt/src/PGT/Output/Text.hs
@@ -63,13 +63,13 @@ mkParserFailure onFailure message = do
           . fst
           $ Text.splitAt (Text.fromPos position) string
 
-impureParseEmptyLine :: String -> Parser ()
-impureParseEmptyLine = either Err.error pure <=< mkParseEmptyLines 1
+impureParseEmptyLine :: Text -> Parser ()
+impureParseEmptyLine = eitherImpureError <=< mkParseEmptyLines 1
 
-parseEmptyLine :: String -> Parser ()
-parseEmptyLine = either fail pure <=< mkParseEmptyLines 1
+parseEmptyLine :: Text -> Parser ()
+parseEmptyLine = eitherFail <=< mkParseEmptyLines 1
 
-mkParseEmptyLines :: Natural -> String -> Parser (Either String ())
+mkParseEmptyLines :: Natural -> Text -> Parser (Either Text ())
 mkParseEmptyLines expectedLines message = do
   receivedLines <- Foldable.length <$> Text.many' Text.endOfLine
 
@@ -77,7 +77,7 @@ mkParseEmptyLines expectedLines message = do
     then pure $ pure ()
     else pure
       . Left
-      $ "found " <> show receivedLines <> " empty lines " <> message <> " instead of " <> show expectedLines
+      $ "found " <> showc receivedLines <> " empty lines " <> message <> " instead of " <> showc expectedLines
 
 parseLineChars :: Parser Text
 parseLineChars = Text.takeWhile1 Char.isPrint <* Text.endOfLine

--- a/pgt/src/PGT/Output/Text.hs
+++ b/pgt/src/PGT/Output/Text.hs
@@ -1,5 +1,9 @@
 module PGT.Output.Text
-  ( impureParseEmptyLine
+  ( eitherFail
+  , eitherImpureError
+  , errorP
+  , failP
+  , impureParseEmptyLine
   , mkParseEmptyLines
   , parseEmptyLine
   , parseLineChars
@@ -11,15 +15,53 @@ module PGT.Output.Text
 where
 
 import Data.Attoparsec.Text (Parser)
+import Data.Int (Int)
+import Data.Tuple (fst)
 import Data.Word (Word8)
 import GHC.Integer (Integer)
 import PGT.Prelude
 
-import qualified Data.Attoparsec.Text as Text
-import qualified Data.Char            as Char
-import qualified Data.Foldable        as Foldable
-import qualified Data.Text            as Text
-import qualified GHC.Err              as Err
+import qualified Data.Attoparsec.Internal.Types as Text
+import qualified Data.Attoparsec.Text           as Text
+import qualified Data.Char                      as Char
+import qualified Data.Foldable                  as Foldable
+import qualified Data.Text                      as Text
+import qualified GHC.Err                        as Err
+
+eitherFail :: Either Text a -> Parser a
+eitherFail = either failP pure
+
+eitherImpureError :: Either Text a -> Parser a
+eitherImpureError = either errorP pure
+
+errorP :: Text -> Parser a
+errorP = mkParserFailure Err.error
+
+failP :: Text -> Parser a
+failP = mkParserFailure fail
+
+mkParserFailure
+  :: (String -> Parser a)
+  -> Text
+  -> Parser a
+mkParserFailure onFailure message = do
+  linePosition <- getLinePosition
+
+  onFailure
+    $ convert message <> " at line: " <> show linePosition
+  where
+    getLinePosition :: Parser Int
+    getLinePosition
+      = Text.Parser
+      $ \textBuffer position more _failure success ->
+            success textBuffer position more . getLineNumber position $ showc textBuffer
+      where
+        getLineNumber :: Text.Pos -> Text -> Int
+        getLineNumber position string
+          = Foldable.length
+          . Text.splitOn "\\n"
+          . fst
+          $ Text.splitAt (Text.fromPos position) string
 
 impureParseEmptyLine :: String -> Parser ()
 impureParseEmptyLine = either Err.error pure <=< mkParseEmptyLines 1


### PR DESCRIPTION
* The line position in current error messages matches the last successfully parsed line in a document.
  In most cases, this is the desired position, but in some, we want the preceding line. 
  Future works will improve the precision of line positions in error messages.
  
* [x] Depends on #217
