### PR TITLE
stack-deploy: Change to simpler instance spec names

### DIFF
--- a/stack-deploy/package.yaml
+++ b/stack-deploy/package.yaml
@@ -1,7 +1,7 @@
 _common/package: !include "../common/package.yaml"
 
 name:        stack-deploy
-version:     0.0.6
+version:     0.0.7
 synopsis:    Utilities around cloudformation templates
 license:     BSD3
 
@@ -16,6 +16,7 @@ dependencies:
 - amazonka-s3             >= 2.0
 - attoparsec              >= 0.13
 - base
+- bounded
 - bytestring
 - conduit                 >= 1.3
 - containers              >= 0.6
@@ -24,10 +25,10 @@ dependencies:
 - filepath                >= 1.4
 - http-types              >= 0.12
 - lens
-- mono-traversable
-- mprelude
 - mio-amazonka
 - mio-core
+- mono-traversable
+- mprelude
 - mtl
 - optparse-applicative    >= 0.14
 - random                  >= 1.1

--- a/stack-deploy/src/StackDeploy/CLI/Utils.hs
+++ b/stack-deploy/src/StackDeploy/CLI/Utils.hs
@@ -1,33 +1,27 @@
 module StackDeploy.CLI.Utils
   ( instanceSpecNameOption
-  , templateNameArgument
   , templateNameOption
   )
 where
 
+import GHC.TypeLits (KnownSymbol)
 import Options.Applicative
 import StackDeploy.Prelude
 
 import qualified StackDeploy.InstanceSpec as InstanceSpec
 import qualified StackDeploy.Template     as Template
 
-instanceSpecNameOption :: Parser (InstanceSpec.Name env)
-instanceSpecNameOption = instanceSpecNameParser (InstanceSpec.mkName <$> str)
-
-templateNameArgument :: Parser Template.Name
-templateNameArgument = Template.mkName <$> argument str (metavar "TEMPLATE")
-
-templateNameOption :: Parser Template.Name
-templateNameOption = templateNameParser (Template.mkName <$> str)
-
-instanceSpecNameParser :: ReadM (InstanceSpec.Name env) -> Parser (InstanceSpec.Name env)
-instanceSpecNameParser reader =
+instanceSpecNameOption :: Parser InstanceSpec.Name
+instanceSpecNameOption =
   option
     reader
     (long "instance" <> metavar "INSTANCE" <> help "Stack instance name")
 
-templateNameParser :: ReadM Template.Name -> Parser Template.Name
-templateNameParser reader =
+templateNameOption :: Parser Template.Name
+templateNameOption =
   option
     reader
     (long "template" <> metavar "TEMPLATE" <> help "Template name")
+
+reader :: KnownSymbol a => ReadM (BoundText a)
+reader = maybeReader (convertMaybe . convert @Text)

--- a/stack-deploy/src/StackDeploy/InstanceSpec.hs
+++ b/stack-deploy/src/StackDeploy/InstanceSpec.hs
@@ -6,7 +6,6 @@ module StackDeploy.InstanceSpec
   , addTags
   , get
   , mk
-  , mkName
   , templateProvider
   )
 where
@@ -29,7 +28,7 @@ newtype RoleARN = RoleARN Text
   deriving (Conversion Text) via Text
   deriving stock Eq
 
-type Name env = Provider.Name (InstanceSpec env)
+type Name = BoundText "StackDeploy.InstanceSpec.Name"
 
 type Provider env = Provider.Provider (InstanceSpec env)
 
@@ -37,19 +36,20 @@ data InstanceSpec env = InstanceSpec
   { capabilities  :: [CF.Capability]
   , envParameters :: MIO env Parameters
   , envRoleARN    :: Maybe (MIO env RoleARN)
-  , name          :: Name env
+  , name          :: Name
   , onSuccess     :: MIO env ()
   , parameters    :: Parameters
   , roleARN       :: Maybe RoleARN
   , template      :: Template
   }
 
-instance Provider.HasName (InstanceSpec env) where
+instance Provider.HasItemName (InstanceSpec env) where
+  type ItemName (InstanceSpec env) = Name
   name = (.name)
 
 get
   :: Provider env
-  -> Name env
+  -> Name
   -> Parameters
   -> MIO env (InstanceSpec env)
 get provider targetName userParameters = do
@@ -75,7 +75,7 @@ get provider targetName userParameters = do
 
     union = Parameters.union
 
-mk :: Name env -> Template -> InstanceSpec env
+mk :: Name -> Template -> InstanceSpec env
 mk name template = InstanceSpec
   { capabilities  = empty
   , envParameters = pure Parameters.empty
@@ -85,9 +85,6 @@ mk name template = InstanceSpec
   , roleARN       = empty
   , ..
   }
-
-mkName :: Text -> Name env
-mkName = Provider.mkName
 
 templateProvider :: Provider env -> Template.Provider
 templateProvider provider = fromList $ (.template) <$> toList provider

--- a/stack-deploy/src/StackDeploy/Prelude.hs
+++ b/stack-deploy/src/StackDeploy/Prelude.hs
@@ -1,10 +1,12 @@
 module StackDeploy.Prelude (module Exports) where
 
-import Control.Monad.Catch  as Exports (MonadThrow, throwM)
-import Control.Monad.Reader as Exports (ask)
-import Data.Conversions     as Exports
-import GHC.Exts             as Exports (IsList, Item, fromList, toList)
-import GHC.Records          as Exports (getField)
-import MIO.Core             as Exports
-import MPrelude             as Exports
-import UnliftIO.Exception   as Exports (catchJust, throwIO, throwString)
+import Control.Monad.Catch       as Exports (MonadThrow, throwM)
+import Control.Monad.Reader      as Exports (ask)
+import Data.Bounded.Text         as Exports
+import Data.Conversions          as Exports
+import Data.Conversions.FromType as Exports
+import GHC.Exts                  as Exports (IsList, Item, fromList, toList)
+import GHC.Records               as Exports (getField)
+import MIO.Core                  as Exports
+import MPrelude                  as Exports
+import UnliftIO.Exception        as Exports (catchJust, throwIO, throwString)

--- a/stack-deploy/src/StackDeploy/Template.hs
+++ b/stack-deploy/src/StackDeploy/Template.hs
@@ -5,7 +5,6 @@ module StackDeploy.Template
   , encode
   , get
   , mk
-  , mkName
   , testTree
   )
 where
@@ -22,14 +21,15 @@ import qualified Stratosphere
 import qualified Test.Tasty               as Tasty
 import qualified Test.Tasty.MGolden       as Tasty
 
-type Name = Provider.Name Template
+type Name = BoundText "StackDeploy.Template.Name"
 
 data Template = Template
   { name         :: Name
   , stratosphere :: Stratosphere.Template
   }
 
-instance Provider.HasName Template where
+instance Provider.HasItemName Template where
+  type ItemName Template = Name
   name = (.name)
 
 type Provider = Provider.Provider Template
@@ -48,9 +48,6 @@ get = Provider.get "template"
 
 mk :: Name -> Stratosphere.Template -> Template
 mk = Template
-
-mkName :: Text -> Name
-mkName = Provider.mkName
 
 testTree :: Provider -> Tasty.TestTree
 testTree provider

--- a/stack-deploy/src/StackDeploy/Template/Code.hs
+++ b/stack-deploy/src/StackDeploy/Template/Code.hs
@@ -5,12 +5,11 @@ import StackDeploy.Template
 import StackDeploy.Utils
 import Stratosphere hiding (Template)
 
-import qualified StackDeploy.Template   as Template
 import qualified Stratosphere.S3.Bucket as S3
 
 template :: Template
 template
-  = mk (Template.mkName "code")
+  = mk (fromType @"code")
   $ Stratosphere.mkTemplate [codeBucket]
   & set @"Outputs" outputs
   where

--- a/stack-deploy/stack-deploy.cabal
+++ b/stack-deploy/stack-deploy.cabal
@@ -1,11 +1,11 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.35.1.
+-- This file has been generated from package.yaml by hpack version 0.35.2.
 --
 -- see: https://github.com/sol/hpack
 
 name:           stack-deploy
-version:        0.0.6
+version:        0.0.7
 synopsis:       Utilities around cloudformation templates
 homepage:       https://github.com/mbj/mhs#readme
 bug-reports:    https://github.com/mbj/mhs/issues
@@ -90,6 +90,7 @@ library
     , amazonka-s3 >=2.0
     , attoparsec >=0.13
     , base
+    , bounded
     , bytestring
     , conduit >=1.3
     , containers >=0.6
@@ -169,6 +170,7 @@ test-suite test
     , amazonka-s3 >=2.0
     , attoparsec >=0.13
     , base
+    , bounded
     , bytestring
     , conduit >=1.3
     , containers >=0.6

--- a/stack-deploy/test/stack-9.2-dependencies.txt
+++ b/stack-deploy/test/stack-9.2-dependencies.txt
@@ -33,6 +33,7 @@ binary 0.8.9.0
 blaze-builder 0.4.2.2
 blaze-html 0.9.1.2
 blaze-markup 0.8.2.8
+bounded 0.0.5
 byteorder 1.0.4
 bytestring 0.11.4.0
 cabal-doctest 1.0.9
@@ -139,7 +140,7 @@ socks 0.6.1
 source-constraints 0.0.4
 split 0.2.3.5
 splitmix 0.1.0.4
-stack-deploy 0.0.6
+stack-deploy 0.0.7
 stm 2.5.0.2
 stratosphere 1.0.0
 stratosphere-ecs 1.0.0
@@ -148,6 +149,7 @@ stratosphere-s3 1.0.0
 streaming-commons 0.2.2.6
 strict 0.4.0.1
 syb 0.7.2.3
+symbols 0.3.0.0
 tagged 0.8.6.1
 tasty 1.4.3
 tasty-expected-failure 0.12.3

--- a/stack-deploy/test/stack-9.4-dependencies.txt
+++ b/stack-deploy/test/stack-9.4-dependencies.txt
@@ -37,6 +37,7 @@ bitvec 1.1.4.0
 blaze-builder 0.4.2.2
 blaze-html 0.9.1.2
 blaze-markup 0.8.2.8
+bounded 0.0.5
 byteorder 1.0.4
 bytestring 0.11.4.0
 cabal-doctest 1.0.9
@@ -146,7 +147,7 @@ socks 0.6.1
 source-constraints 0.0.4
 split 0.2.3.5
 splitmix 0.1.0.4
-stack-deploy 0.0.6
+stack-deploy 0.0.7
 stm 2.5.1.0
 stratosphere 1.0.0
 stratosphere-ecs 1.0.0
@@ -155,6 +156,7 @@ stratosphere-s3 1.0.0
 streaming-commons 0.2.2.6
 strict 0.5
 syb 0.7.2.3
+symbols 0.3.0.0
 tagged 0.8.7
 tasty 1.4.3
 tasty-expected-failure 0.12.3


### PR DESCRIPTION
* The previous InstanceSpec.Name type was a phantom type gone wrong / rouge.
* It should never have leaked the `env` parameter in the first place.