### PR TITLE
[dbt] Fix DBT.Migration.readMigrationFiles for multiple extensions

### DIFF
--- a/dbt/src/DBT/Migration.hs
+++ b/dbt/src/DBT/Migration.hs
@@ -231,14 +231,14 @@ readMigrationFiles = do
         fmap pure . readMigration file =<< parseIndex file
 
     isMigrationFile :: Path.RelFile -> Bool
-    isMigrationFile = (== ".sql") . Path.takeExtension
+    isMigrationFile = (== ".sql") . Path.takeExtensions
 
     parseIndex :: Path.RelFile -> MIO env Natural
     parseIndex file =
       maybe
         (throwString $ "Invalid migration file name: " <> Path.toString file)
         pure
-        (readMaybe . Path.toString $ Path.dropExtension file)
+        (readMaybe . Path.toString $ Path.dropExtensions file)
 
     readMigration :: Path.RelFile -> Natural -> MIO env MigrationFile
     readMigration path index = do


### PR DESCRIPTION
Valid `dbt` migration files must use `.sql` as their single file extension.
