### PR TITLE
Add pgt {test,update}-no-lint commands to skip output post processing

### DIFF
--- a/pgt/src/PGT/CLI.hs
+++ b/pgt/src/PGT/CLI.hs
@@ -43,10 +43,12 @@ parserInfoCommand = wrapHelper subcommands
 
     subcommands =
       CLI.subparser
-        $  mkCommand "list"   runList
-        <> mkCommand "run"    runExamples
-        <> mkCommand "test"   (runTests PGT.impureParse)
-        <> mkCommand "update" (runUpdates PGT.impureParse)
+        $  mkCommand "list"           runList
+        <> mkCommand "run"            runExamples
+        <> mkCommand "test"           (runTests PGT.impureParse)
+        <> mkCommand "test-no-lint"   (runTests identity)
+        <> mkCommand "update"         (runUpdates PGT.impureParse)
+        <> mkCommand "update-no-lint" (runUpdates identity)
 
     mkCommand
       :: String

--- a/pgt/src/PGT/CLI.hs
+++ b/pgt/src/PGT/CLI.hs
@@ -10,6 +10,7 @@ import PGT.Selector
 
 import qualified Data.Vector         as Vector
 import qualified Options.Applicative as CLI
+import qualified PGT.Output          as PGT
 import qualified System.Exit         as System
 import qualified System.IO           as IO
 import qualified System.Path         as Path
@@ -44,8 +45,8 @@ parserInfoCommand = wrapHelper subcommands
       CLI.subparser
         $  mkCommand "list"   runList
         <> mkCommand "run"    runExamples
-        <> mkCommand "test"   runTests
-        <> mkCommand "update" runUpdates
+        <> mkCommand "test"   (runTests PGT.impureParse)
+        <> mkCommand "update" (runUpdates PGT.impureParse)
 
     mkCommand
       :: String


### PR DESCRIPTION
The current output processing is too inflexible when it comes to allowing initial experimentation when developing a pgt test. Most attempts to render data to aid with debugging are rejected with not really helpful error messages (pointing to line numbers that are hard/impossible to verify, as no `.expected` files get written if post processing fails).