### PR TITLE
Change pgt build to create binary

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -75,7 +75,11 @@ jobs:
     - name: Install dependencies
       run: ./stack build --test --only-dependencies
     - name: Build
+      if: matrix.project != 'pgt'
       run: ./stack build --fast --test --no-run-tests ${{ matrix.project }}
+    - name: Build pgt binary
+      if: matrix.project == 'pgt'
+      run: ./stack build --fast --test --no-run-tests --copy-bins --flag pgt:build-executable ${{ matrix.project }}
     - name: Run tests
       run: ./stack build --fast --test ${{ matrix.project }}
   all-checks:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -82,6 +82,13 @@ jobs:
       run: ./stack build --fast --test --no-run-tests --copy-bins --flag pgt:build-executable ${{ matrix.project }}
     - name: Run tests
       run: ./stack build --fast --test ${{ matrix.project }}
+    - name: Add pgt binary artifact
+      if: matrix.project == 'pgt'
+      uses: actions/upload-artifact@v3
+      with:
+        name: pgt-linux-x86-64
+        path: /home/runner/.local/bin/pgt
+        if-no-files-found: error
   all-checks:
     runs-on: ubuntu-latest
     name: All Checks Pass


### PR DESCRIPTION
### Summary

This branch builds the pgt binary and persists it as an artifact that can be downloaded later.

### Acceptance

* [x] Verify the pgt.zip can be downloaded and unzipped and run on a linux machine.